### PR TITLE
refactor: 로그아웃 후 재로그인시 계정을 선택할 수 있도록 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Devoops는 개발 중 망각되는 고민들을 자동으로 수집하여 회고
 |<img width="633" height="563" alt="스크린샷 2025-07-24 오후 4 55 16" src="https://github.com/user-attachments/assets/dbcf19b6-547f-4ded-a3f6-1857004818a3" />|
 |:--:|
 
+<br />
+
 ## 🧑🏻‍💻Developers
 
 <table>

--- a/src/app/auth/github/callback/page.tsx
+++ b/src/app/auth/github/callback/page.tsx
@@ -12,11 +12,7 @@ async function GithubAuthCallbackPage({ searchParams }: Props) {
   const { code } = await searchParams;
 
   if (!code) {
-    return (
-      <div>
-        <h1>{'code가 없습니다.'}</h1>
-      </div>
-    );
+    throw new Error('코드가 없습니다.');
   }
 
   try {

--- a/src/app/auth/github/page.tsx
+++ b/src/app/auth/github/page.tsx
@@ -6,8 +6,14 @@ const GITHUB_AUTH_URL = `${GITHUB_API_URL}/login/oauth/authorize`;
 const CLIENT_ID = process.env.GITHUB_CLIENT_ID;
 const REDIRECT_URI = process.env.GITHUB_REDIRECT_URI;
 
-const GithubAuthPage = () => {
-  redirect(`${GITHUB_AUTH_URL}?client_id=${CLIENT_ID}&redirect_uri=${REDIRECT_URI}&scope=read:user user:email repo`);
-};
+export default function GithubAuthPage() {
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID!,
+    redirect_uri: REDIRECT_URI!,
+    scope: 'read:user user:email repo',
+    state: crypto.randomUUID(),
+    prompt: 'select_account',
+  });
 
-export default GithubAuthPage;
+  redirect(`${GITHUB_AUTH_URL}?${params.toString()}`);
+}

--- a/src/components/auth/GithubCallback.tsx
+++ b/src/components/auth/GithubCallback.tsx
@@ -3,10 +3,9 @@
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
-import RepoLoadingModal from '../common/Modal/RepoLoadingModal/RepoLoadingModal';
-
 import { apiApi } from '@/__generated__/Api/Api.api';
 import { getTokenAction, setTokenAction } from '@/actions/token.action';
+import RepoLoadingModal from '@/components/common/Modal/RepoLoadingModal/RepoLoadingModal';
 
 function GithubCallback({ accessToken, refreshToken }: { accessToken: string; refreshToken: string }) {
   const router = useRouter();

--- a/src/components/landing/Section/HeroSection.tsx
+++ b/src/components/landing/Section/HeroSection.tsx
@@ -46,7 +46,7 @@ export default function HeroSection({ action }: HeroSectionProps) {
           'border-dark-grey-200 shadow-landing-image mx-auto mt-[67px] max-w-[1000px] overflow-hidden rounded-tl-[28px] rounded-tr-[28px] border-1'
         }
       >
-        <Image src={LandingHero} alt={'Landing Hero'} />
+        <Image src={LandingHero} alt={'Landing Hero'} priority />
       </div>
       <GradientBottomLayer />
     </section>


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close https://github.com/mash-up-kr/devoops-web/issues/70

- 로그아웃 후 로그인 시, 자동 로그인 되는 문제를 해결했습니다.
- 그 외 자잘한 부분도 함께 수정했습니다

## Why?

- 로그아웃 후 이미 github 계정이 로그인 되어 있다면 유저를 교체하지 못하고 동일한 계정으로 바로 로그인이 되었기 때문입니다.

## How?

- 핵심적으로 prompt=select_account 파라미터를 담아서 redirect 하는 형식으로 수정했습니다.
- 이 과정에서 csrf 문제가 발생할수도 있다하여 state를 통해 난수를 담아 보냅니다.
	- [GitHub 공식 문서](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps)에도 state를 “Strongly recommended”로 표시하고 있습니다. 

| 다음과 같이 계정을 선택할 수 있는 창이 뜸 |
|:---:|
|<img width="675" height="555" alt="스크린샷 2025-07-29 오후 9 16 53" src="https://github.com/user-attachments/assets/f73c5b2c-13ee-449b-a41b-cabba9707547" />|

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * GitHub 인증 시 OAuth 요청에 `state`(UUID)와 `prompt` 파라미터가 추가되어 보안과 사용자 선택 기능이 향상되었습니다.
  * 랜딩 페이지의 주요 이미지를 우선적으로 로드하여 페이지 표시 속도가 개선되었습니다.

* **버그 수정**
  * GitHub 인증 콜백에서 인증 코드가 없을 경우 즉시 예외를 발생시켜 더 명확하게 오류를 처리합니다.

* **문서**
  * README에 섹션 간 줄바꿈이 추가되어 가독성이 개선되었습니다.

* **리팩터**
  * GitHub 인증 페이지의 쿼리 문자열 생성 방식이 개선되어 코드의 안정성이 향상되었습니다.
  * 일부 컴포넌트의 import 경로가 절대 경로로 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->