### PR TITLE
refactor: PR Item 클릭 시, 회고 페이지로 넘어가게 수정

### DIFF
--- a/src/components/home/QuestionTabs/QuestionContent.tsx
+++ b/src/components/home/QuestionTabs/QuestionContent.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { QuestionBriefResponseType } from '@/__generated__/@types';
 import Button from '@/components/common/Button';
 import QuestionItem from '@/components/home/QuestionTabs/QuestionItem';
+import { ROUTES } from '@/constants/routes';
 import { filterBy } from '@/utils/filter';
 
 interface QuestionContentProps {
@@ -17,9 +18,9 @@ interface QuestionContentProps {
 export default function QuestionContent({ pullRequestId, questions, activeCategory }: QuestionContentProps) {
   const router = useRouter();
 
-  const handleClick = (prId: number | undefined) => {
+  const navigateToRetrospective = (prId: number | undefined) => {
     if (prId) {
-      router.push(`/retrospective/${prId}`);
+      router.push(ROUTES.PAGE.RETROSPECTIVE(prId));
     }
   };
 
@@ -39,7 +40,7 @@ export default function QuestionContent({ pullRequestId, questions, activeCatego
         <Button
           className={'text-body-large cursor-pointer font-semibold'}
           disabled={!pullRequestId}
-          onClick={() => handleClick(pullRequestId)}
+          onClick={() => navigateToRetrospective(pullRequestId)}
         >
           {'자세히보기'}
         </Button>

--- a/src/components/home/RepositoryList.tsx
+++ b/src/components/home/RepositoryList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { Suspense, useEffect, useMemo, useState } from 'react';
 
 import { RepositoryPullRequestResponseType, RepositorySummaryType } from '@/__generated__/@types';
@@ -18,6 +19,7 @@ import Preview from '@/components/home/Preview';
 import { PRContent, PRItem, PRStatus } from '@/components/home/PRItem';
 import PreviewSkeleton from '@/components/home/Skeleton/PreviewSkeleton';
 import PRListSkeleton from '@/components/home/Skeleton/PRListSkeleton';
+import { ROUTES } from '@/constants/routes';
 import { usePagination } from '@/hooks/usePagination';
 
 interface RepositoryListProps {
@@ -83,10 +85,12 @@ export default function RepositoryList({ repository }: RepositoryListProps) {
     <div className={'flex'}>
       <div className={'border-dark-grey-100 flex flex-1 flex-col gap-5 border-e-1 py-4 pe-8'}>
         {PRList.map((pr) => (
-          <PRItem key={pr.id} onMouseOver={() => handlePRItemOver(pr)}>
-            <PRStatus status={pr.recordStatus} />
-            <PRContent content={pr.title} label={pr.tag || ''} />
-          </PRItem>
+          <Link href={ROUTES.PAGE.RETROSPECTIVE(pr.id)} key={pr.id}>
+            <PRItem onMouseOver={() => handlePRItemOver(pr)}>
+              <PRStatus status={pr.recordStatus} />
+              <PRContent content={pr.title} label={pr.tag || 'NONE'} />
+            </PRItem>
+          </Link>
         ))}
         <Pagination>
           <PaginationContent>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,9 @@
+export const ROUTES = {
+  PAGE: {
+    HOME: '/',
+    LANDING: '/landing',
+    AUTH_GITHUB: '/auth/github',
+    REPOLINK: '/repolink',
+    RETROSPECTIVE: (prId: number | undefined) => `/retrospective/${prId}`,
+  },
+} as const;


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?
close https://github.com/mash-up-kr/devoops-web/issues/74
- PR Item 클릭 시, 회고 페이지로 넘어가게 작업해 두었습니다.
- 경로에 대한 상수 값을 관리 하기 위해 파일을 새로 하나 만들었습니다.
	- 경로에 대한 통합관리를 통해 실수를 줄이고 수정을 쉽게 하기 위함입니다.

## Why?

- 런칭데이에서 유저 테스트를 진행해보니, PR List에 있는 Item을 클릭해서 이동하려는 유저들이 많았습니다.
	- 이러한 점을 고려해 PR Item을 클릭해도 회고 페이지로 넘어갈 수 있게 작업해 두었습니다.

## How?

### 고민한 점 (next/link 사용과 외부 router.push를 통한 이동)
Next에서 페이지를 이동할때 크게 두가지 방식이 있다고 생각했습니다.
1. Next 에서 제공하는 next/link 컴포넌트를 쓴다.
2. router.push를 통해 이동시킨다.

button과 같은 경우는 Link로 감싸는게 클릭이벤트를 사용하지 않는다는 점이 어색하게 느껴져서 onClick을 통해 router.push를 하는데, 이번 PR Item의 경우에는 div 형태의 컴포넌트여서 고민이 되었던 것 같습니다.

결론적으론 **next/link 컴포넌트**를 썻습니다. 그 이유는 다음과 같습니다.
1. router.push보다 SEO에 더 적합하다.
2. 자동 프리페치가 지원된다.
3. useRouter로 인한 `use client`를 쓰지 않아도 된다.
4. 부가적으로 핸들링 되어야 하는 로직이 없다.

## Check List

- [x] Merge 할 브랜치가 올바른가?