### PR TITLE
refactor: 회고 완료 버튼 두 번 이상 클릭 시 회고 박스가 사라지는 이슈 해결 

### DIFF
--- a/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
@@ -206,7 +206,7 @@ export default function RetrospectivePage() {
         setSelectedQuestionIds((prev) => (prev.includes(questionId) ? prev : [...prev, questionId]));
       }
     } catch {
-      alert('회고 답변 생성에 실패했습니다.');
+      // 에러 무시
     }
   };
 

--- a/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
@@ -32,18 +32,14 @@ export default function RetrospectivePage() {
 
   const queryClient = useQueryClient();
 
-  // 페이지 진입 시 항상 refetch
   useEffect(() => {
     if (!pullRequestId) return;
     queryClient.invalidateQueries({ queryKey: ['pullRequestDetail', Number(pullRequestId)] });
+    queryClient.removeQueries({ queryKey: ['pullRequestDetail', Number(pullRequestId)] });
   }, [pullRequestId, queryClient]);
 
-  // 쿠키 기반 user 정보 가져오기
   const { data: userData, isLoading: userLoading } = useGetMyInfoQuery({});
   const user = userData?.data || null;
-
-  // user가 null이 아닌 시점에만 아래 훅을 호출
-  // const { data: rawData, isLoading, error } = usePullRequestDetail(Number(pullRequestId), user);
 
   const {
     data: rawData,
@@ -55,10 +51,11 @@ export default function RetrospectivePage() {
     },
     options: {
       enabled: !!pullRequestId && !!user,
+      refetchOnMount: true,
+      refetchOnWindowFocus: false,
+      staleTime: 0,
     },
   });
-
-  // const data = rawData as PullRequestDetailReadResponseType | undefined;
 
   const { autoSaveStatus } = useAutoSave({
     user,
@@ -75,39 +72,30 @@ export default function RetrospectivePage() {
     debounceMs: 3000,
   });
 
-  // --- [추가] rawData가 로드되면 answerId가 있는 질문을 자동 선택 및 답변 세팅 ---
+  // 서버 데이터 기반으로 최신 상태 렌더링
   useEffect(() => {
     if (!rawData?.data?.questions) return;
 
-    // recordStatus가 DONE이면 회고 완료 상태로 설정
     if (rawData.data.recordStatus === 'DONE') {
       setIsRetrospectiveDone(true);
     }
 
-    // answerId가 있는 질문만
     const preSelected = rawData.data.questions.filter((q) => q.answerId != null);
-    // 이미 선택된 질문이 없을 때만 초기화
-    setSelectedQuestionIds((prev) =>
-      prev.length === 0 ? preSelected.map((q) => q.questionId!).filter((id): id is number => id !== undefined) : prev,
-    );
+    setSelectedQuestionIds(preSelected.map((q) => q.questionId!).filter((id): id is number => id !== undefined));
+
     const newAnswers = preSelected.map((q) => ({
       answerId: q.answerId!,
       questionId: q.questionId!,
       content: q.answer ?? '',
     }));
 
-    setAnswers((prev) => {
-      if (prev.length > 0) return prev;
-      return newAnswers;
-    });
+    setAnswers(newAnswers);
 
-    // recordStatus가 DONE이면 lastSubmittedAnswers도 설정
     if (rawData.data.recordStatus === 'DONE') {
       setLastSubmittedAnswers(newAnswers.map(({ answerId, content }) => ({ answerId, content })));
     }
   }, [rawData?.data?.questions, rawData?.data?.recordStatus]);
 
-  // 모든 훅 호출 후에 조건부 렌더링
   if (userLoading || isLoading) return <RetrospectivePageSkeleton />;
   if (!user) return <div>{'로그인이 필요합니다.'}</div>;
   if (error || !rawData?.data) return <div>{'데이터를 불러오지 못했습니다.'}</div>;
@@ -196,17 +184,14 @@ export default function RetrospectivePage() {
     });
   };
 
-  // Add back handleDeleteAnswer and handleSelectQuestion
   const handleDeleteAnswer = async (questionId: number) => {
     const answerObj = answers.find((a) => a.questionId === questionId);
     if (!answerObj) return;
-    try {
-      await apiApi.deleteAnswer({ answerId: answerObj.answerId, data: { content: answerObj.content } });
-      setAnswers((prev) => prev.filter((a) => a.questionId !== questionId));
-      setSelectedQuestionIds((prev) => prev.filter((id) => id !== questionId));
-    } catch {
-      alert('회고 답변 삭제에 실패했습니다.');
-    }
+
+    await apiApi.deleteAnswer({ answerId: answerObj.answerId, data: { content: '' } });
+    setAnswers((prev) => prev.filter((a) => a.questionId !== questionId));
+    setSelectedQuestionIds((prev) => prev.filter((id) => id !== questionId));
+    setLastSubmittedAnswers((prev) => prev.filter((a) => a.answerId !== answerObj.answerId));
   };
 
   const handleSelectQuestion = async (questionId: number) => {

--- a/src/app/auth/github/callback/page.tsx
+++ b/src/app/auth/github/callback/page.tsx
@@ -28,9 +28,8 @@ async function GithubAuthCallbackPage({ searchParams }: Props) {
         <GithubCallback accessToken={userData.accessToken ?? ''} refreshToken={userData.refreshToken ?? ''} />
       </div>
     );
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log('토큰 설정 실패', error);
+  } catch {
+    // 토큰 설정 실패
   }
 }
 

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -38,20 +38,8 @@ export default function FixedFooter({
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const hasChanges = () => {
-    return answers.some((a) => {
-      const prev = lastSubmittedAnswers.find((p) => p.answerId === a.answerId);
-      return !prev || prev.content !== a.content;
-    });
-  };
-
   const handleComplete = async () => {
     if (isRefreshing) return;
-
-    // 완료된 상태에서 수정사항이 없으면 처리하지 않음
-    if (isCompleted && !hasChanges()) {
-      return;
-    }
     // answerId가 없는 값이 있으면 요청을 보내지 않음
     const invalidAnswers = answers.filter((a) => typeof a.answerId !== 'number' || Number.isNaN(a.answerId));
     if (invalidAnswers.length > 0) {
@@ -123,8 +111,7 @@ export default function FixedFooter({
             updateAllAnswersMutation.isPending ||
             updateAnswerMutation.isPending ||
             markPRAsDoneMutation.isPending ||
-            isRefreshing ||
-            (isCompleted && !hasChanges()) // 완료된 상태에서 수정사항이 없을 때만 비활성화
+            isRefreshing
           }
         >
           {isRefreshing ? '새로고침 중...' : '회고완료'}

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -38,13 +38,30 @@ export default function FixedFooter({
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
 
+  const hasChanges = () => {
+    // 답변 개수가 다르면 변경사항이 있음 (삭제된 경우)
+    if (answers.length !== lastSubmittedAnswers.length) {
+      return true;
+    }
+
+    // 답변 내용이 다르면 변경사항이 있음
+    return answers.some((a) => {
+      const prev = lastSubmittedAnswers.find((p) => p.answerId === a.answerId);
+      return !prev || prev.content !== a.content;
+    });
+  };
+
   const handleComplete = async () => {
     if (isRefreshing) return;
+
+    // 변경사항이 없으면 fetch 보내지 않음
+    if (isCompleted && !hasChanges()) {
+      return;
+    }
+
     // answerId가 없는 값이 있으면 요청을 보내지 않음
     const invalidAnswers = answers.filter((a) => typeof a.answerId !== 'number' || Number.isNaN(a.answerId));
     if (invalidAnswers.length > 0) {
-      console.error('answerId가 없는 답변이 있습니다:', invalidAnswers);
-      alert('답변 저장 중 오류가 발생했습니다. 새로고침 후 다시 시도해 주세요.');
       return;
     }
     const emptyQuestionIds = answers


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- 회고 완료 버튼 두 번 이상 클릭 시 회고 박스가 사라지는 이슈를 해결한다 
- 이 외 회고 페이지에 존재하는 작은 이슈들을 해결한다. (불필요한 api 호출, 렌더링 오류 등) 

## Why?

- 회고 완료 버튼을 두 번 이상 클릭한 경우, 불필요하게 api가 호출되며 회고 페이지에서 회고 박스가 사라지기 때문 

## How?

- 회고 완료 시 중복 초기화 방지
  - `handleRetrospectiveComplete` 함수에서 `isRetrospectiveDone`이 이미 true일 때는 답변과 선택된 질문을 초기화하지 않도록 수정
- 답변 삭제 로직 개선
  - `deleteAnswer` API 호출 시 올바른 data 파라미터를 전달하도록 수정

## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 회고 페이지에서 데이터 캐시 관리가 강화되어 항상 최신 정보를 불러오도록 개선되었습니다.
  * 회고 완료 처리 및 답변 삭제/생성 시의 오류 처리와 상태 동기화가 더욱 일관성 있게 동작합니다.

* **신규 기능**
  * 회고가 이미 완료된 경우, 추가 변경 사항이 없으면 불필요한 네트워크 요청이 발생하지 않도록 개선되었습니다.

* **스타일/리팩터**
  * 불필요한 콘솔 로그 및 에러 알림이 제거되어 사용자 경험이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->