### PR TITLE
refactor: 각 PRItem의 첫번째 카테고리에 대한 질문 default로 제공하기

### DIFF
--- a/src/components/home/QuestionTabs/CategoryCarousel/CategoryCarousel.tsx
+++ b/src/components/home/QuestionTabs/CategoryCarousel/CategoryCarousel.tsx
@@ -1,29 +1,26 @@
-'use client';
-
 import CategoryCarouselContent from '@/components/home/QuestionTabs/CategoryCarousel/CategoryCarouselContent';
 import CategoryCarouselItem from '@/components/home/QuestionTabs/CategoryCarousel/CategoryCarouselItem';
 import CategoryCarouselNavigator from '@/components/home/QuestionTabs/CategoryCarousel/CategoryCarouselNavigator';
 
 interface CategoryCarouselProps {
   categories: string[];
-  activeCategory: string;
-  setActiveCategory: (category: string) => void;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
 }
 
-export default function CategoryCarousel({ categories, activeCategory, setActiveCategory }: CategoryCarouselProps) {
-  const currentCategoryIndex = categories.findIndex((category) => category === activeCategory);
-  const canGoPrev = currentCategoryIndex > 0;
-  const canGoNext = currentCategoryIndex < categories.length - 1;
+export default function CategoryCarousel({ categories, activeIndex, setActiveIndex }: CategoryCarouselProps) {
+  const canGoPrev = activeIndex > 0;
+  const canGoNext = activeIndex < categories.length - 1;
 
   const goToPrev = () => {
     if (canGoPrev) {
-      setActiveCategory(categories[currentCategoryIndex - 1]);
+      setActiveIndex(activeIndex - 1);
     }
   };
 
   const goToNext = () => {
     if (canGoNext) {
-      setActiveCategory(categories[currentCategoryIndex + 1]);
+      setActiveIndex(activeIndex + 1);
     }
   };
 
@@ -31,13 +28,13 @@ export default function CategoryCarousel({ categories, activeCategory, setActive
     <div className={'mb-6 flex w-full items-center gap-2'}>
       <CategoryCarouselNavigator direction={'prev'} onClick={goToPrev} disabled={!canGoPrev} />
 
-      <CategoryCarouselContent currentIndex={currentCategoryIndex}>
+      <CategoryCarouselContent currentIndex={activeIndex}>
         {categories.map((category, index) => (
           <CategoryCarouselItem
-            key={index}
+            key={`${category}-${index}`}
             category={category}
-            isActive={category === activeCategory}
-            onClick={() => setActiveCategory(category)}
+            isActive={index === activeIndex}
+            onClick={() => setActiveIndex(index)}
           />
         ))}
       </CategoryCarouselContent>

--- a/src/components/home/QuestionTabs/QuestionTabs.tsx
+++ b/src/components/home/QuestionTabs/QuestionTabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { PullRequestReadResponseType } from '@/__generated__/@types';
 import { CategoryCarousel, QuestionContent } from '@/components/home/QuestionTabs';
@@ -12,11 +12,17 @@ interface QuestionTabsProps {
 export default function QuestionTabs({ contents }: QuestionTabsProps) {
   const { categories } = contents;
 
-  const [activeCategory, setActiveCategory] = useState(categories[0] || '');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [categories]);
+
+  const activeCategory = categories[activeIndex] ?? '';
 
   return (
     <>
-      <CategoryCarousel categories={categories} activeCategory={activeCategory} setActiveCategory={setActiveCategory} />
+      <CategoryCarousel categories={categories} activeIndex={activeIndex} setActiveIndex={setActiveIndex} />
       <QuestionContent pullRequestId={contents.id} questions={contents.questions} activeCategory={activeCategory} />
     </>
   );


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #84 

- 기존의 홈에서 PRItem에 마우스를 호버하였을 시, 오른쪽의 Preview에서 카테고리가 눌리지 않아 회고 질문을 미리 볼 수 없었던 이슈가 있었습니다.

|<img width="930" height="786" alt="Image" src="https://github.com/user-attachments/assets/7b340cd8-68c1-4300-8425-e617e57f0f86" />|<img width="930" height="786" alt="Image" src="https://github.com/user-attachments/assets/1de0e62f-dbbc-466c-a8ee-1115998eb1eb" />|
|:---:|:---:|
| as is | to be|

## Why?

- UX 상으로 유저가 카테고리를 선택하지 않아도 첫번째 카테고리를 default로 보여주어, 회고 질문을 자연스럽게 하는 것이 좋다고 판단되었습니다.

## How?

- useEffect를 통해 categories가 불러와지고 나서 categories[0]을 제대로 바인딩 할 수 있도록 해주었습니다.
- 위 방식만으로 #84 이슈에 대한 문제는 해결가능했습니다.
<br />

- 다만, 현재 로직이 category의 이름을 기반으로 activeCategory를 정의하는 방식이라 부가적인 이슈가 있었습니다.
- 다른 PRItem의 첫번째 카테고리와 이름이 같으면 다른 PRItem을 호버했을때 헛번째 카테고리가 아니라 이전의 값에서 선택한 카테고리가 선택되어 졌습니다.

|  <video src="https://github.com/user-attachments/assets/3249ce82-89c8-4ec4-8b08-93c46b9bde38" />|
|:---:|
|부가적인 이슈에 대한 영상|

- 그리하여 이에 대한 로직을 Index 기반으로 수정하였고 현재는 어떤 PRItem을 선택하더라고 첫번째 카테고리를 보여줄 수 있도록 수정했습니다.

|  <video src="https://github.com/user-attachments/assets/fdc29a0c-1031-4db4-a7d3-fe2e828d6db6" />|
|:---:|
|부가적인 이슈에 대한 영상|

## Check List

- [x] Merge 할 브랜치가 올바른가?
