### PR TITLE
feat: Tracking 여부에 따른 레포지토리 상태 구별하기

### DIFF
--- a/src/__generated__/@types/index.ts
+++ b/src/__generated__/@types/index.ts
@@ -9,6 +9,7 @@
  * ---------------------------------------------------------------
  */
 
+
 /**
  * 회고 최신화 요청 목록
  */
@@ -333,11 +334,31 @@ export interface MyRepositoriesResponseType {
   repositories?: RepositorySummaryType[];
 }
 
+/**
+ * 레포지토리 내역
+ */
 export interface RepositorySummaryType {
-  /** @format int64 */
+  /**
+   * 레포지토리 아이디
+   * @format int64
+   * @example 1
+   */
   id?: number;
+  /**
+   * 레포지토리 이름
+   * @example "my-repo"
+   */
   name?: string;
-  /** @format int32 */
+  /**
+   * 레포지토리 추적 여부
+   * @example true
+   */
+  isTracking?: boolean;
+  /**
+   * 레포지토리 풀 리퀘스트 개수
+   * @format int32
+   * @example 10
+   */
   pullRequestCount?: number;
 }
 
@@ -364,7 +385,7 @@ export interface PullRequestDetailReadResponseType {
    */
   recordStatus: 'PENDING' | 'PROGRESS' | 'DONE';
   /**
-   * PR URL
+   * 풀 리퀘스트 url
    * @example "https://github.com/aaa/bbb/pull/4"
    */
   pullRequestUrl: string;

--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -153,6 +153,7 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
                   >
                     <div className={'flex items-center gap-[8px]'}>
                       <div
+                        aria-label={repository.isTracking ? '추적 중인 레포지토리' : '미추적 레포지토리'}
                         className={cn(
                           `h-[8px] w-[8px] rounded-full ${repository.isTracking ? 'bg-dark-blue-500' : 'bg-dark-grey-200'}`,
                         )}

--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -13,6 +13,7 @@ import MonoXIcon from '@/assets/svg/mono_x.svg';
 import RepoEmpty from '@/assets/svg/repo-empty.svg';
 import Button from '@/components/common/Button';
 import { Modal as ModalComponent } from '@/components/common/Modal';
+import { cn } from '@/utils/cn';
 
 interface RepolinkModalProps {
   defaultOpen: boolean;
@@ -151,7 +152,11 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
                     }
                   >
                     <div className={'flex items-center gap-[8px]'}>
-                      <div className={'bg-dark-blue-500 h-[8px] w-[8px] rounded-full'} />
+                      <div
+                        className={cn(
+                          `h-[8px] w-[8px] rounded-full ${repository.isTracking ? 'bg-dark-blue-500' : 'bg-dark-grey-200'}`,
+                        )}
+                      />
                       <p className={'text-body-small text-white'}>{repository.name}</p>
                     </div>
 

--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -63,9 +63,7 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
     const _repositories = repositoriesData?.data?.repositories;
     if (!_repositories?.length) return [];
 
-    return [..._repositories].sort((a, b) => {
-      return Number(b.isTracking) - Number(a.isTracking);
-    });
+    return [..._repositories].sort((a, b) => Number(Boolean(b.isTracking)) - Number(Boolean(a.isTracking)));
   })();
 
   const saveRepository = () => {

--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -61,9 +61,11 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
   const repositories = (() => {
     // eslint-disable-next-line no-underscore-dangle
     const _repositories = repositoriesData?.data?.repositories;
-    if (!_repositories) return [];
-    if (_repositories.length === 0) return [];
-    return _repositories;
+    if (!_repositories?.length) return [];
+
+    return [..._repositories].sort((a, b) => {
+      return Number(b.isTracking) - Number(a.isTracking);
+    });
   })();
 
   const saveRepository = () => {


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?
close #87 
- Tracking 여부에 따라 레포지토리 상태를 구분 할 수 있게 해 두었습니다.
- 트래킹 중인 repo가 상위에 올 수 있도록 정렬 처리를 해두었습니다.

## Why?

- 

## How?

|<img width="429" height="563" alt="image" src="https://github.com/user-attachments/assets/47a7e9d7-4950-4087-9d64-6ed8bf1984e4" />|
|:---:|
| true: 블루컬러 / false: 회색 컬러|

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **개선 사항**
  * 레포지토리 목록이 추적 중인 항목이 상단에 오도록 정렬됩니다.
  * 각 레포지토리 이름 옆의 원형 표시 색상이 추적 여부에 따라 다르게 표시됩니다.
  * 원형 표시에 추적 여부를 설명하는 접근성 레이블(aria-label)이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->