### PR TITLE
feat: [회고] 홈으로 돌아가기 위한 flow를 추가한다. 

### DIFF
--- a/src/components/home/MyPR.tsx
+++ b/src/components/home/MyPR.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-
 import { RepositorySummaryType } from '@/__generated__/@types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/Tabs';
 import RepositoryList from '@/components/home/RepositoryList';
@@ -11,10 +9,6 @@ interface MyPRProps {
 }
 
 export default function MyPR({ initialRepositoryList }: MyPRProps) {
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
   return (
     <div>
       <h1 className={'text-h1 blue-tiny-left inline-block pt-2.5 pb-6 font-semibold'}>{'내 PR'}</h1>

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -115,7 +115,7 @@ export default function FixedFooter({
 
   const handleGoHome = () => {
     // 추후 toast 와 자동저장 구현되면 적용 예정
-    // 저장 중이면 경고
+    // // 저장 중이면 경고
     // if (autoSaveStatus === 'saving') {
     //   const proceedWhileSaving = window.confirm(
     //     '저장 중입니다. 홈으로 이동하시겠어요? 진행 중인 저장이 완료되지 않을 수 있습니다.',
@@ -127,7 +127,8 @@ export default function FixedFooter({
     //   const proceed = window.confirm('작성 중인 회고가 저장되지 않았습니다. 홈으로 이동하시겠어요?');
     //   if (!proceed) return;
     // }
-    router.push('/');
+
+    router.push('/', { scroll: true });
   };
 
   return (


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

Close #83 
- 회고 페이지에서 home으로 돌아갈 수 있는 직관적인 버튼을 추가한다. 


## Why?

- 회고 페이지에서 home으로 돌아갈 수 있는 방법이 상단바의 로고를 클릭하는 것 뿐이라면 사용자 관점에서 불편할 것이라고 생각했다.

## How?

- useRouter의 push 메서드를 사용해서 홈 페이지 경로('/')로 이동

## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * "홈으로" 버튼이 추가되어 회고 작성 화면에서 홈 페이지로 바로 이동할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->