### PR TITLE
fix: 회고완료 시 API 파라미터 구조를 서버 스펙에 맞게 수정

### DIFF
--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -83,7 +83,7 @@ export default function FixedFooter({
     try {
       if (lastSubmittedAnswers.length === 0) {
         // First submit 처리
-        await updateAllAnswersMutation.mutateAsync({ answers });
+        await updateAllAnswersMutation.mutateAsync({ data: { answers } });
         setLastSubmittedAnswers([...answers]);
       } else {
         // Subsequent submit 처리
@@ -93,7 +93,12 @@ export default function FixedFooter({
         });
         if (changed.length > 0) {
           await Promise.all(
-            changed.map((ans) => updateAnswerMutation.mutateAsync({ answerId: ans.answerId, content: ans.content })),
+            changed.map((ans) =>
+              updateAnswerMutation.mutateAsync({
+                answerId: ans.answerId,
+                data: { content: ans.content },
+              }),
+            ),
           );
           setLastSubmittedAnswers([...answers]);
         }


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

Closes #99 

- 회고완료 버튼 클릭 시 API 호출 파라미터 구조를 서버 스펙에 맞게 수정

## Why?

-

## How?
updateAnswerMutation: { answerId, content } → { answerId, data: { content } }
updateAllAnswersMutation: { answers } → { data: { answers } }

content와 answers가 data 객체 안에 감싸져서 전송되도록 수정했습니다 .. 😅


## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 사용자에게 보이는 기능 변경 없음.
- 리팩터
  - 답변 저장 요청의 데이터 구조를 일관된 형식으로 정리하여 제출 흐름을 통일.
  - 최초 제출과 이후 수정 시 동일한 래핑 구조를 적용해 처리 일관성 강화.
- 유지보수(Chores)
  - 내부 호출부를 새로운 데이터 구조에 맞춰 정리하고 계약을 최신화하여 안정성을 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->