### PR TITLE
refactor: isTracking 유무에 따른 정렬

### DIFF
--- a/src/app/(with-layout)/page.tsx
+++ b/src/app/(with-layout)/page.tsx
@@ -1,16 +1,19 @@
 import { RepositorySummaryType } from '@/__generated__/@types';
 import { apiApi } from '@/__generated__/Api/Api.api';
 import MyPR from '@/components/home/MyPR';
+import { sortRepositoriesByTracking } from '@/utils/sortRepositoriesByTracking';
 
 export default async function Home() {
   let initialRepositoryList: RepositorySummaryType[];
 
   try {
-    const { data: myReposRes } = await apiApi.getMyRepositories();
-    const repos = myReposRes.repositories ?? [];
+    const { data: myRepositories } = await apiApi.getMyRepositories();
+    const repositoriesData = myRepositories.repositories ?? [];
+    const sortedRepositoriesByTracking = sortRepositoriesByTracking(repositoriesData);
+    console.log(sortedRepositoriesByTracking);
 
-    const totalCount = repos.reduce((sum, r) => sum + (r.pullRequestCount || 0), 0);
-    initialRepositoryList = [{ id: 0, name: '전체', pullRequestCount: totalCount }, ...repos];
+    const totalCount = repositoriesData.reduce((sum, r) => sum + (r.pullRequestCount || 0), 0);
+    initialRepositoryList = [{ id: 0, name: '전체', pullRequestCount: totalCount }, ...sortedRepositoriesByTracking];
   } catch {
     initialRepositoryList = [];
   }

--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -18,6 +18,7 @@ import { RepolinkButton } from '@/components/common/Modal/RepolinkModal/index';
 import { REDIRECT_NO_PERMISSION_URL } from '@/constants/domain';
 import { MODAL_ID } from '@/constants/modal';
 import { cn } from '@/utils/cn';
+import { sortRepositoriesByTracking } from '@/utils/sortRepositoriesByTracking';
 
 interface RepolinkModalProps {
   defaultOpen: boolean;
@@ -79,7 +80,7 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
     // eslint-disable-next-line no-underscore-dangle
     const _repositories = repositoriesData?.data?.repositories;
     if (!_repositories?.length) return [];
-    return [..._repositories].sort((a, b) => Number(Boolean(b.isTracking)) - Number(Boolean(a.isTracking)));
+    return sortRepositoriesByTracking(_repositories);
   })();
 
   const saveRepository = () => {

--- a/src/utils/sortRepositoriesByTracking.ts
+++ b/src/utils/sortRepositoriesByTracking.ts
@@ -1,0 +1,5 @@
+import { RepositorySummaryType } from '@/__generated__/@types';
+
+export function sortRepositoriesByTracking(repositories: RepositorySummaryType[]) {
+  return repositories.sort((a, b) => Number(Boolean(b?.isTracking)) - Number(Boolean(a?.isTracking)));
+}


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- 트래킹 여부에 따라 홈의 탭 리스트를 정렬될 수 있게 해두었습니다.
- 이 과정에서 중복되는 함수를 `sortRepositoriesByTracking`으로 묶어 따로 빼두었습니다.

## Why?

- #87 에서 레포지토지 추가 페이지에서는 반영되었던 정렬이 홈에서는 적용되지 않아 사용성에 불편함이 있었습니다.

## How?

|<img width="970" height="119" alt="스크린샷 2025-09-02 오전 8 14 18" src="https://github.com/user-attachments/assets/772fcd29-cc36-47e2-8ce1-ded047c975bb" />|<img width="556" height="726" alt="스크린샷 2025-09-02 오전 8 43 32" src="https://github.com/user-attachments/assets/b3b04314-7209-4e86-af9b-f68a8a822cc6" />|
|:---:|:---:|
|홈 탭 리스트 정렬|레포지토리 추가 페이지 정렬|

- PR 개수와는 상관 없이, 단순 Tracking 유무에 따른 정렬처리만 해 두었습니다.

## Check List

- [x] Merge 할 브랜치가 올바른가?
