### PR TITLE
refactor: QuestionItem 컴포넌트 구조를 Accordion 형태로 수정

### DIFF
--- a/src/components/home/AISummary.tsx
+++ b/src/components/home/AISummary.tsx
@@ -6,13 +6,7 @@ export default function AISummary({ contents }: AISummaryProps) {
   return (
     <div className={'flex flex-col gap-2'}>
       <div className={'text-body-small text-dark-grey-500 font-medium'}>{'AI 요약'}</div>
-      <div
-        className={`
-          text-body-medium font-regular text-dark-grey-700
-        `}
-      >
-        {contents}
-      </div>
+      <div className={`text-body-medium font-regular text-dark-grey-700 break-all`}>{contents}</div>
     </div>
   );
 }

--- a/src/components/home/QuestionTabs/QuestionContent.tsx
+++ b/src/components/home/QuestionTabs/QuestionContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { QuestionBriefResponseType } from '@/__generated__/@types';
 import Button from '@/components/common/Button';
@@ -10,13 +10,14 @@ import { ROUTES } from '@/constants/routes';
 import { filterBy } from '@/utils/filter';
 
 interface QuestionContentProps {
-  pullRequestId: number | undefined;
+  pullRequestId: number;
   questions: QuestionBriefResponseType[];
   activeCategory: string;
 }
 
 export default function QuestionContent({ pullRequestId, questions, activeCategory }: QuestionContentProps) {
   const router = useRouter();
+  const [openQuestionId, setOpenQuestionId] = useState<number | null>(null);
 
   const navigateToRetrospective = (prId: number | undefined) => {
     if (prId) {
@@ -24,12 +25,23 @@ export default function QuestionContent({ pullRequestId, questions, activeCatego
     }
   };
 
+  const handleToggleQuestion = (questionId: number) => {
+    setOpenQuestionId((prevOpenId) => (prevOpenId === questionId ? null : questionId));
+  };
+
   const matchedQuestionByCategory = filterBy(questions, 'category', activeCategory);
 
   return (
     <div className={'space-y-3'}>
       {matchedQuestionByCategory.map(({ id, category, content }) => (
-        <QuestionItem key={id} id={id} category={category} content={content} />
+        <QuestionItem
+          key={id}
+          id={id}
+          category={category}
+          content={content}
+          isOpen={openQuestionId === id}
+          onToggle={() => handleToggleQuestion(id ?? 0)}
+        />
       ))}
 
       {matchedQuestionByCategory.length === 0 && (

--- a/src/components/home/QuestionTabs/QuestionItem.tsx
+++ b/src/components/home/QuestionTabs/QuestionItem.tsx
@@ -1,12 +1,44 @@
-import React from 'react';
-
 import { QuestionBriefResponseType } from '@/__generated__/@types';
+import { cn } from '@/utils/cn';
 
-export default function QuestionItem({ category, content }: QuestionBriefResponseType) {
+interface QuestionItemProps extends QuestionBriefResponseType {
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+const CONTENT_TRUNCATE_THRESHOLD = 85;
+
+export default function QuestionItem({ category, content = '', isOpen, onToggle }: QuestionItemProps) {
+  const isContentLong = content.length > CONTENT_TRUNCATE_THRESHOLD;
+
   return (
-    <div className={`bg-dark-grey-25 flex flex-col gap-2 rounded-xl p-5`}>
+    <div
+      className={cn(
+        'bg-dark-grey-25 relative flex flex-col gap-2 rounded-xl p-5 transition-all duration-500',
+        isContentLong && (isOpen ? 'max-h-[500px]' : 'max-h-35.5 overflow-hidden'),
+      )}
+    >
       <div className={'text-body-small text-dark-blue-700 font-semibold'}>{category}</div>
-      <h5 className={'text-h5 text-dark-grey-800 font-medium'}>{content}</h5>
+      <h5 className={cn('text-body-medium text-dark-grey-800 font-medium break-all', isContentLong && 'pb-6')}>
+        {content}
+      </h5>
+      {isContentLong && (
+        <div className={'absolute right-0 bottom-0 left-0'}>
+          {!isOpen && (
+            <div className={'absolute bottom-0 h-12 w-full [background:var(--color-gradient-question-item-button)]'} />
+          )}
+          <div className={'relative'}>
+            <button
+              className={
+                'text-body-small text-dark-grey-500 w-full cursor-pointer border-none py-2 font-medium outline-none hover:text-dark-grey-700'
+              }
+              onClick={onToggle}
+            >
+              {isOpen ? '접기' : '더보기'}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -79,6 +79,7 @@
     rgba(96, 139, 247, 0.05) 15%,
     rgba(96, 139, 247, 0) 100%
   );
+  --color-gradient-question-item-button: linear-gradient(180deg, rgb(20, 21, 26, 0) 0%, rgba(20, 21, 26, 0.95) 20%, rgb(20, 21, 26) 100%);
 
   /* Shadow Colors */
   --shadow-modal: 0px 12px 50px 0px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #119 

- 질문 미리보기의 QuestionItem 컴포넌트의 형태를 Accordion으로 수정했습니다.
- 글자수가 85자(대략 2줄)가 넘어간다면 해당 컴포넌트에 대해서 접고 펼수 있는 구조로 만들어 두었습니다.
- 바이브 코딩 좀 했습니다.. 수정 해야합니다. 우선 QA를 위해 반영하고 최우선 사항으로 수정해보려 합니다.

## Why?
|<img width="501" height="811" alt="스크린샷 2025-09-02 오전 8 46 52" src="https://github.com/user-attachments/assets/122cf721-fa29-4935-8b47-c242e24d5d0e" />|
|:---:|

- 현재의 형태는 단순 나열식인데, 이 경우 질문의 개수가 많아지면 가독성이 저하되고 UI가 한 없이 길어지는 문제가 있었습니다.

## How?

|<img width="1680" height="985" alt="스크린샷 2025-09-02 오후 8 56 57" src="https://github.com/user-attachments/assets/521394eb-c231-4794-b7ae-f4a1c094e7ee" />|<img width="1680" height="985" alt="스크린샷 2025-09-02 오후 8 57 04" src="https://github.com/user-attachments/assets/71851aa2-2f33-40fe-9416-5c2304ef3498" />|
|:---:|:---:|
|85자를 넘기는 경우|넘지 않는 경우|

|<video src="https://github.com/user-attachments/assets/222429d2-55ab-4ed6-9f29-10375d5d31fa" />|
|:---:|
|시연 영상|

## Check List

- [x] Merge 할 브랜치가 올바른가?
