### PR TITLE
chore: 서비스 명 `Devoops`로 통일

### DIFF
--- a/src/components/landing/Section/FeatureSection.tsx
+++ b/src/components/landing/Section/FeatureSection.tsx
@@ -21,12 +21,12 @@ export default function FeatureSection() {
                 {'회고, 더는 어렵지 않아요.'}
               </h1>
               <h1 className={'blue-tiny-right inline-block text-[48px] leading-[64px] font-bold'}>
-                {'DevOops가 다 챙겨줄게요.'}
+                {'Devoops가 다 챙겨줄게요.'}
               </h1>
             </div>
           </div>
           <div className={'text-body-large text-dark-grey-600 text-center text-[18px] font-medium'}>
-            <p>{'레포지토리 연동만 해두면, 요약도 질문도 DevOops가 알아서 챙겨줘요. '}</p>
+            <p>{'레포지토리 연동만 해두면, 요약도 질문도 Devoops가 알아서 챙겨줘요. '}</p>
           </div>
         </div>
       </div>

--- a/src/components/landing/Section/FooterCTA.tsx
+++ b/src/components/landing/Section/FooterCTA.tsx
@@ -9,10 +9,10 @@ export default function FooterCTA({ action }: FooterCTAProps) {
     <div>
       <div className={'mx-auto mb-[48px] flex items-center justify-center gap-8 py-[96px]'}>
         <h1 className={'text-h1 blue-tiny-right inline-block leading-[58px] font-bold'}>
-          {'복잡한 회고, DevOops가 슬쩍 정리해줄게요.'}
+          {'복잡한 회고, Devoops가 슬쩍 정리해줄게요.'}
         </h1>
         <Button variant={'filledPrimary'} size={'medium'} onClick={action}>
-          {'DevOops 시작하기'}
+          {'Devoops 시작하기'}
         </Button>
       </div>
     </div>

--- a/src/components/landing/Section/HeroSection.tsx
+++ b/src/components/landing/Section/HeroSection.tsx
@@ -31,7 +31,7 @@ export default function HeroSection({ action }: HeroSectionProps) {
             </p>
             <p>
               <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
-                {' 가볍게 적다 보면 중요한 게 자연'}
+                {'가볍게 적다 보면 중요한 게 자연'}
               </span>
               {'스럽게 남아요.'}
             </p>

--- a/src/components/landing/Section/HeroSection.tsx
+++ b/src/components/landing/Section/HeroSection.tsx
@@ -23,7 +23,7 @@ export default function HeroSection({ action }: HeroSectionProps) {
           </div>
           <div className={'text-dark-grey-600 flex flex-col text-center text-[18px] leading-[29px] font-medium'}>
             <p>
-              {'DevOops가 '}
+              {'Devoops가 '}
               <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
                 {'PR을 요약하고 고민을 되살리는 질문'}
               </span>
@@ -38,7 +38,7 @@ export default function HeroSection({ action }: HeroSectionProps) {
           </div>
         </div>
         <Button variant={'filledPrimary'} size={'medium'} onClick={action}>
-          {'DevOops 시작하기'}
+          {'Devoops 시작하기'}
         </Button>
       </div>
       <div

--- a/src/components/landing/Section/RepolinkSection.tsx
+++ b/src/components/landing/Section/RepolinkSection.tsx
@@ -26,7 +26,7 @@ export default function RepolinkSection() {
               </span>
               {'이에요.'}
             </p>
-            <p>{'이제 회고는 DevOops가 자동으로 챙겨드려요.'}</p>
+            <p>{'이제 회고는 Devoops가 자동으로 챙겨드려요.'}</p>
           </div>
         </div>
       </div>

--- a/src/components/landing/Section/StartSection.tsx
+++ b/src/components/landing/Section/StartSection.tsx
@@ -18,7 +18,7 @@ export default function StartSection() {
             {'AI를 통한 간편한 회고'}
           </Tag>
           <h1 className={'blue-tiny-right inline-block text-[48px] leading-[58px] font-bold'}>
-            {'DevOops로 회고를 시작해볼까요?'}
+            {'Devoops로 회고를 시작해볼까요?'}
           </h1>
         </div>
         <div>


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #125 
- `DevOops`와 `Devoops`로 나눠진 서비스 명을 `Devoops`로 통일했습니다.

## Why?

- UT 사항 중 서비스 명이 통합되면 좋을 것 같다는 의견이 있어서 합당하다 생각했기 때문입니다.

## How?

-

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 랜딩 페이지 전반의 브랜드 표기를 DevOops에서 Devoops로 일괄 업데이트했습니다: Hero, Feature, Footer CTA, Repolink, Start 섹션의 헤더/설명/버튼 라벨에 반영.
  * 문장 내 불필요한 공백을 제거해 문장 표시를 보다 자연스럽게 정리했습니다.
  * 사용자에게 보이는 텍스트의 일관성과 가독성이 향상되었으며 기능상의 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->