### PR TITLE
feat: 질문 추가 버튼 두 번 클릭시 질문 선택이 취소되게 한다

### DIFF
--- a/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
@@ -198,6 +198,16 @@ export default function RetrospectivePage() {
   };
 
   const handleSelectQuestion = async (questionId: number) => {
+    // 이미 선택된 질문인지 확인
+    const isAlreadySelected = selectedQuestionIds.includes(questionId);
+
+    if (isAlreadySelected) {
+      // 이미 선택된 질문이면 선택 해제 (삭제)
+      await handleDeleteAnswer(questionId);
+      return;
+    }
+
+    // 선택되지 않은 질문이면 선택 (추가)
     try {
       const res = await createAnswerMutation.mutateAsync({ questionId });
       const answerId = res.data.id;
@@ -206,7 +216,7 @@ export default function RetrospectivePage() {
         if (!alreadyAnswered) {
           setAnswers((prev) => [...prev, { answerId, questionId, content: '' }]);
         }
-        setSelectedQuestionIds((prev) => (prev.includes(questionId) ? prev : [...prev, questionId]));
+        setSelectedQuestionIds((prev) => [...prev, questionId]);
       }
     } catch {
       // 에러 무시


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

Closes #129 
<img width="1175" height="733" alt="image" src="https://github.com/user-attachments/assets/d9385df5-21ec-4c9d-87fc-4664e0afac0b" />

- 선택한 질문을 삭제할 수 있는 방법을 추가하였다. (기존에는 휴지통 아이콘을 클릭하는 방법으로만 선택 취소가 가능했는데, 변경 후에는 체크 아이콘을 클릭하는 방법으로도 취소할 수 있다.)

## Why?

- 사용자 편의성 증가 

## How?

질문 선택/해제 토글 로직 추가
 - 같은 질문을 다시 클릭하면 선택 해제되도록 isAlreadySelected 체크 로직 구현
 - 선택된 질문은 handleDeleteAnswer로 삭제, 선택되지 않은 질문은 createAnswerMutation으로 추가

## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 회고 질문 목록에서 이미 선택된 질문을 다시 클릭하면 즉시 선택 해제되고 관련 답변이 제거되는 토글 동작이 추가되었습니다.

* 버그 수정
  * 동일한 질문을 반복 선택할 때 발생하던 중복 답변 생성이 방지되어 목록에 중복 항목이 나타나지 않습니다.
  * 질문 선택/해제 시 선택 상태와 답변 목록의 동기화가 개선되어 더 일관된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->