### PR TITLE
style: 레포지토리 추가 모달에 대한 UT 사항 반영

### DIFF
--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -144,7 +144,7 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
                   value={input}
                   onChange={(e) => setInput(e.target.value)}
                   className={
-                    'text-body-medium text-dark-grey-900 border-dark-grey-200 h-[48px] w-[300px] rounded-[8px] border-[1px] px-[14px] py-[12px] placeholder:text-dark-grey-900'
+                    'placeholder-dark-grey-500 text-body-medium text-dark-grey-900 border-dark-grey-200 h-[48px] w-[300px] rounded-[8px] border-[1px] px-[14px] py-[12px]'
                   }
                   type={'text'}
                   placeholder={'레포지토리 주소를 입력해 주세요'}

--- a/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
+++ b/src/components/common/Modal/RepolinkModal/RepolinkModal.tsx
@@ -134,7 +134,7 @@ function RepolinkModal({ defaultOpen = false, isOutsideClickClose = false, butto
 
             <section className={'flex w-[380px] flex-col items-center justify-center gap-[8px]'}>
               <h3 className={'text-h3 pt-4.5'}>{'회고할 레포지토리를 추가해 주세요!'}</h3>
-              <p className={'text-body-small text-dark-grey-600'}>{'레포지토리는 5개까지 추가할 수 있어요'}</p>
+              <p className={'text-body-small text-dark-grey-600'}>{'레포지토리는 5개까지 연동할 수 있어요'}</p>
             </section>
 
             <form className={'mt-[40px] flex w-full flex-col'}>


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #131 
- placeholder 색상을 변경했습니다.
- 레포지토리 추가에 대한 설명의 워딩을 `추가 -> 연동` 으로 수정했습니다.

## Why?

- 유저 테스트 후 결정된 사항을 반영하기 위함입니다.

## How?

|<img width="507" height="582" alt="스크린샷 2025-09-13 오후 10 55 10" src="https://github.com/user-attachments/assets/b1f642c2-93a6-469f-bc5e-ad734b1449b1" />|
|:---:|
|수정된 모달|


## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 레포지토리 안내 문구를 “레포지토리는 5개까지 연동할 수 있어요”로 수정하여 사용자에게 더 명확한 가이드를 제공합니다.
  * 레포지토리 입력창의 플레이스홀더 색상을 전용 유틸리티로 정리하고 톤을 조정해 가독성과 시각적 일관성을 향상했습니다.
  * 입력 필드 스타일 클래스 정렬을 개선해 테마 적용의 일관성과 유지보수성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->