### PR TITLE
style: 탭 리스트 상태에 따른 색상 수정

### DIFF
--- a/src/components/common/Spacing.tsx
+++ b/src/components/common/Spacing.tsx
@@ -1,0 +1,10 @@
+export default function Spacing({ size }: { size: number }) {
+  return (
+    <div
+      style={{
+        flex: 'none',
+        height: size,
+      }}
+    />
+  );
+}

--- a/src/components/common/Tabs/TabsTrigger.tsx
+++ b/src/components/common/Tabs/TabsTrigger.tsx
@@ -58,13 +58,13 @@ export default function TabsTrigger({
         tabsTriggerVariants({ size }),
         isActive
           ? `
-            enabled:text-on-surface-high enabled:inset-shadow-tabs-active
+            enabled:text-dark-grey-900 enabled:inset-shadow-tabs-active
             enabled:font-semibold
           `
           : `
             hover:enabled:text-dark-grey-700
             hover:enabled:inset-shadow-tabs-hover
-            enabled:text-shadow-on-surface-lowest
+            enabled:text-dark-grey-600
             enabled:inset-shadow-tabs-enabled
           `,
         disabled && `disabled:text-dark-grey-300 disabled:cursor-not-allowed`,

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -45,8 +45,10 @@ export const dotVariants = cva('inline-block h-1.5 w-1.5 rounded-full', {
   },
 });
 
+export type TagDotColor = VariantProps<typeof dotVariants>['dotColor'];
+
 interface TagProps {
-  dotColor: VariantProps<typeof dotVariants>['dotColor'];
+  dotColor: TagDotColor;
   children: ReactNode;
   size?: VariantProps<typeof textVariants>['size'];
   padding?: VariantProps<typeof tagVariants>['padding'];

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -27,7 +27,7 @@ const textVariants = cva('text-dark-grey-800', {
   },
 });
 
-const dotVariants = cva('inline-block h-1.5 w-1.5 rounded-full', {
+export const dotVariants = cva('inline-block h-1.5 w-1.5 rounded-full', {
   variants: {
     dotColor: {
       violet: 'bg-sub-violet',
@@ -38,6 +38,8 @@ const dotVariants = cva('inline-block h-1.5 w-1.5 rounded-full', {
       skyblue: 'bg-sub-skyblue',
       gray: 'bg-dark-grey-300',
       red: 'bg-sub-red',
+      lime: 'bg-lime-300',
+      rose: 'bg-rose-300',
       primary: 'bg-primary',
     },
   },

--- a/src/components/home/MyPR.tsx
+++ b/src/components/home/MyPR.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 
 import { RepositorySummaryType } from '@/__generated__/@types';
 import { RepolinkButton, RepolinkModal } from '@/components/common/Modal/RepolinkModal';
+import Spacing from '@/components/common/Spacing';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/common/Tabs';
 import Overview from '@/components/home/Overview';
 import { useModalDispatch } from '@/providers/ModalContext';
@@ -43,6 +44,7 @@ export default function MyPR({ initialRepositoryList }: MyPRProps) {
             ))}
           </div>
         </Tabs>
+        <Spacing size={400} />
       </div>
       <RepolinkModal defaultOpen={false} isOutsideClickClose button={<div />} />
     </>

--- a/src/components/home/Overview.tsx
+++ b/src/components/home/Overview.tsx
@@ -101,7 +101,7 @@ export default function Overview({ repository }: OverviewProps) {
           <Link href={ROUTES.PAGE.RETROSPECTIVE(pr.id || 0)} key={pr.id}>
             <PRItem onMouseOver={() => handlePRItemOver(pr)}>
               <PRStatus status={pr.recordStatus} />
-              <PRContent content={pr.title} label={pr.tag || 'NONE'} />
+              <PRContent content={pr.title} label={pr.tag || 'none'} />
             </PRItem>
           </Link>
         ))}

--- a/src/components/retrospective/RetrospectiveHeader.tsx
+++ b/src/components/retrospective/RetrospectiveHeader.tsx
@@ -1,6 +1,7 @@
 import { format } from 'date-fns';
 
 import Tag from '@/components/common/Tag';
+import { getTagColor } from '@/utils/getTagColor';
 
 interface RetrospectiveHeaderProps {
   title: string;
@@ -22,7 +23,7 @@ export default function RetrospectiveHeader({
     <header
       className={'border-outline-variant flex flex-col items-start justify-start gap-[6px] border-b-[1px] pb-[36px]'}
     >
-      <Tag dotColor={'violet'}>{tag}</Tag>
+      <Tag dotColor={getTagColor(tag)}>{tag}</Tag>
       <div>
         <h1 className={'text-h1 font-semibold'}>{title}</h1>
         <div className={'text-body-small text-on-surface-low font-regular flex gap-[8px]'}>

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -1,10 +1,31 @@
+import type { VariantProps } from 'class-variance-authority';
+
+import { dotVariants } from '@/components/common/Tag';
+
+type TagKeys = 'feat' | 'refactor' | 'bug' | 'chore' | 'style' | 'test' | 'pref' | 'deploy' | 'fix' | 'none';
+
+const tagColors: Record<TagKeys, VariantProps<typeof dotVariants>['dotColor']> = {
+  feat: 'skyblue',
+  refactor: 'violet',
+  bug: 'red',
+  chore: 'olive',
+  style: 'orange',
+  test: 'blue',
+  pref: 'yellow',
+  deploy: 'lime',
+  fix: 'rose',
+  none: 'gray',
+};
+
+const findMatchingTag = (tagName: string) => {
+  const checkTag = Object.keys(tagColors).find((tag) => {
+    return new RegExp(tag, 'i').test(tagName);
+  });
+
+  return checkTag || 'none';
+};
+
 export const getTagColor = (tagName: string) => {
-  if (tagName.includes('feat')) return 'skyblue';
-  if (tagName.includes('refactor')) return 'violet';
-  if (tagName.includes('bug')) return 'red';
-  if (tagName.includes('chore')) return 'olive';
-  if (tagName.includes('style')) return 'orange';
-  if (tagName.includes('test')) return 'blue';
-  if (tagName.includes('pref')) return 'yellow';
-  return 'gray';
+  const foundTag = findMatchingTag(tagName);
+  return tagColors[foundTag as TagKeys];
 };

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -1,6 +1,6 @@
 import type { TagDotColor } from '@/components/common/Tag';
 
-type TagKeys = 'feat' | 'refactor' | 'bug' | 'chore' | 'style' | 'test' | 'pref' | 'deploy' | 'fix' | 'none';
+type TagKeys = 'feat' | 'refactor' | 'bug' | 'chore' | 'style' | 'test' | 'perf' | 'deploy' | 'fix' | 'none';
 
 const tagColors: Record<TagKeys, TagDotColor> = {
   feat: 'skyblue',
@@ -9,7 +9,7 @@ const tagColors: Record<TagKeys, TagDotColor> = {
   chore: 'olive',
   style: 'orange',
   test: 'blue',
-  pref: 'yellow',
+  perf: 'yellow',
   deploy: 'lime',
   fix: 'rose',
   none: 'gray',

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -1,10 +1,8 @@
-import type { VariantProps } from 'class-variance-authority';
-
-import { dotVariants } from '@/components/common/Tag';
+import type { TagDotColor } from '@/components/common/Tag';
 
 type TagKeys = 'feat' | 'refactor' | 'bug' | 'chore' | 'style' | 'test' | 'pref' | 'deploy' | 'fix' | 'none';
 
-const tagColors: Record<TagKeys, VariantProps<typeof dotVariants>['dotColor']> = {
+const tagColors: Record<TagKeys, TagDotColor> = {
   feat: 'skyblue',
   refactor: 'violet',
   bug: 'red',
@@ -22,10 +20,10 @@ const findMatchingTag = (tagName: string) => {
     return new RegExp(tag, 'i').test(tagName);
   });
 
-  return checkTag || 'none';
+  return (checkTag || 'none') as TagKeys;
 };
 
 export const getTagColor = (tagName: string) => {
   const foundTag = findMatchingTag(tagName);
-  return tagColors[foundTag as TagKeys];
+  return tagColors[foundTag];
 };


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #133 

- 탭 리스트와 PR Item에 대해서 호버 시 색상을 일관되게 통일했습니다.
- `Spacing` 컴포넌트를 만들어 홈 하단의 여백을 만들었습니다.
- 기존의 `getTagColor`의 함수의 문제점을 해결하고 홈과 회고페이지의 라벨 태그 컬러를 통일시켰습니다.

## Why?

- 유저 테스트 후 결정된 사항을 반영하기 위함입니다.

## How?

1. 탭 리스트와 PR Item에 대해서 호버 시 색상을 일관되게 통일했습니다.
	- active 된 것만, 흰색으로 표현되도록 하였습니다.

|<img width="635" height="438" alt="스크린샷 2025-09-14 오전 1 29 15" src="https://github.com/user-attachments/assets/573173e6-0a7f-49c2-b59a-c569b8d6fed5" />|<img width="635" height="438" alt="스크린샷 2025-09-14 오전 1 29 27" src="https://github.com/user-attachments/assets/71cfa333-1b82-4131-b20e-9bd9a70e68fa" />|
|:---:|:---:|
|before|after|

2. `Spacing` 컴포넌트를 만들어 홈 하단의 여백을 만들었습니다.

|<img width="1680" height="933" alt="스크린샷 2025-09-14 오전 1 40 31" src="https://github.com/user-attachments/assets/64f130ce-5e2c-466f-86ed-9d90c562ef3a" />|<img width="1680" height="933" alt="스크린샷 2025-09-14 오전 1 40 24" src="https://github.com/user-attachments/assets/df2e8e8a-fb5f-46d7-9bde-30aac2c73ad3" />|
|:---:|:---:|
|before|after|

3. 기존의 `getTagColor`의 함수의 문제점을 해결하고 홈과 회고페이지의 라벨 태그 컬러를 통일시켰습니다.

|<img width="636" height="819" alt="스크린샷 2025-09-14 오전 1 50 53" src="https://github.com/user-attachments/assets/553a1a6d-68c3-4723-a415-cf281d786d45" />|<img width="636" height="819" alt="스크린샷 2025-09-14 오전 1 50 46" src="https://github.com/user-attachments/assets/b1e0c051-b109-45f1-8010-abad14da37ef" />|
|:---:|:---:|
|before|after|

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 새로운 세로 간격(Spacing) 컴포넌트 도입으로 화면 구간 간 여백 추가
  - 내 PR 화면에 큰 세로 여백 추가로 가독성 개선
  - 태그 점 색상 옵션에 lime/rose 추가
  - 회고 헤더에서 태그 값에 따라 점 색상이 자동 적용

- Style
  - 탭 활성/비활성 텍스트 색상 토큰 조정으로 대비 개선
  - PR 태그 기본 라벨을 ‘NONE’에서 ‘none’으로 통일 적용
  - 태그 색상 매핑 로직 개선으로 더 일관된 태그 색상 표시
<!-- end of auto-generated comment: release notes by coderabbit.ai -->