### PR TITLE
chore: 회고 질문 텍스트 오버플로우로 인한 레이아웃 깨짐 현상 해결 해결

### DIFF
--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -87,7 +87,7 @@ export default function RetrospectiveAnswers({
                 className={'bg-dark-grey-50 relative flex flex-col gap-[8px] rounded-[8px] px-[24px] py-[20px]'}
               >
                 <div className={'flex items-center justify-between'}>
-                  <p className={'text-body-medium font-semibold'}>{question.content}</p>
+                  <p className={'text-body-medium font-semibold break-all'}>{question.content}</p>
                   {onDeleteAnswer && (
                     <button
                       type={'button'}

--- a/src/components/retrospective/RetrospectiveQuestions.tsx
+++ b/src/components/retrospective/RetrospectiveQuestions.tsx
@@ -38,7 +38,7 @@ export default function RetrospectiveQuestions({
                   }
                   key={questionId}
                 >
-                  <p className={'grow-1'}>{question}</p>
+                  <p className={'grow-1 break-all'}>{question}</p>
                   <button onClick={() => onSelectQuestion(questionId)} className={'cursor-pointer'}>
                     {selectedQuestionIds.includes(questionId) ? <CheckIcon /> : <PlusIcon />}
                   </button>


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #138 

- 회고 질문 텍스트 오버플로우로 인한 레이아웃 깨짐 현상을 해결하였습니다.

<img width="700"  alt="image" src="https://github.com/user-attachments/assets/328b7bd4-e1bb-4122-8d3c-895aee02e735" />


## Why?

-

## How?

- 회고 박스에 break-all 속성을 적용하였습니다.
- https://tailwindcss.com/docs/word-break

## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 회고 질문/답변 화면의 질문 텍스트에 강제 줄바꿈(break-all)을 적용했습니다. 긴 단어·URL도 단어 중간에서 줄이 바뀌어 가로 스크롤, 오버플로우, 겹침 없이 표시됩니다.
  - 반응형 환경에서 다양한 화면 폭에서도 일관된 레이아웃을 유지합니다.
  - 기능, 데이터, 상태 로직 변경은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->