### PR TITLE
[회고] 홈으로 버튼 삭제 + (회고 완료 | 임시저장) 으로 구성하기

### DIFF
--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -114,6 +114,9 @@ export default function FixedFooter({
       await queryClient.refetchQueries({ queryKey: ['pullRequestDetail', Number(pullRequestId)] });
       setIsRefreshing(false);
       if (onComplete) onComplete();
+
+      // 홈으로 리다이렉트
+      router.push('/', { scroll: true });
     } catch (error) {
       console.error('회고 완료 실패', error);
       setIsRefreshing(false);
@@ -146,6 +149,9 @@ export default function FixedFooter({
     >
       <div className={'flex items-center gap-4'}>
         <AutoSaveStatus status={autoSaveStatus} />
+        <Button variant={'outlineGrey'} size={'medium'} onClick={handleGoHome}>
+          {'임시 저장'}
+        </Button>
         <Button
           variant={'filledPrimary'}
           size={'medium'}
@@ -159,9 +165,6 @@ export default function FixedFooter({
           }
         >
           {isRefreshing ? '새로고침 중...' : '회고완료'}
-        </Button>
-        <Button variant={'filledPrimary'} size={'medium'} onClick={handleGoHome}>
-          {'홈으로'}
         </Button>
       </div>
     </footer>

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -88,6 +88,7 @@ export default function FixedFooter({
 
     // 변경사항이 없는 경우
     if (isCompleted && !hasChanges()) {
+      router.push('/', { scroll: true });
       return;
     }
 

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -164,23 +164,41 @@ export default function FixedFooter({
     >
       <div className={'flex items-center gap-4'}>
         <AutoSaveStatus status={autoSaveStatus} />
-        <Button variant={'outlineGrey'} size={'medium'} onClick={handleTempSave}>
-          {'임시 저장'}
-        </Button>
-        <Button
-          variant={'filledPrimary'}
-          size={'medium'}
-          onClick={handleComplete}
-          disabled={
-            answers.length === 0 ||
-            updateAllAnswersMutation.isPending ||
-            updateAnswerMutation.isPending ||
-            markPRAsDoneMutation.isPending ||
-            isRefreshing
-          }
-        >
-          {isRefreshing ? '새로고침 중...' : '회고완료'}
-        </Button>
+        {!isCompleted ? (
+          <>
+            <Button variant={'outlineGrey'} size={'medium'} onClick={handleTempSave}>
+              {'임시 저장'}
+            </Button>
+            <Button
+              variant={'filledPrimary'}
+              size={'medium'}
+              onClick={handleComplete}
+              disabled={
+                answers.length === 0 ||
+                updateAllAnswersMutation.isPending ||
+                updateAnswerMutation.isPending ||
+                markPRAsDoneMutation.isPending ||
+                isRefreshing
+              }
+            >
+              {isRefreshing ? '새로고침 중...' : '회고 완료'}
+            </Button>
+          </>
+        ) : (
+          <Button
+            variant={'filledPrimary'}
+            size={'medium'}
+            onClick={handleComplete}
+            disabled={
+              answers.length === 0 ||
+              updateAllAnswersMutation.isPending ||
+              updateAnswerMutation.isPending ||
+              isRefreshing
+            }
+          >
+            {isRefreshing ? '새로고침 중...' : '저장'}
+          </Button>
+        )}
       </div>
     </footer>
   );

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -123,21 +123,36 @@ export default function FixedFooter({
     }
   };
 
-  const handleGoHome = () => {
-    // 추후 toast 와 자동저장 구현되면 적용 예정
-    // // 저장 중이면 경고
-    // if (autoSaveStatus === 'saving') {
-    //   const proceedWhileSaving = window.confirm(
-    //     '저장 중입니다. 홈으로 이동하시겠어요? 진행 중인 저장이 완료되지 않을 수 있습니다.',
-    //   );
-    //   if (!proceedWhileSaving) return;
-    // }
-    // // 변경사항이 있으면 경고
-    // if (hasChanges()) {
-    //   const proceed = window.confirm('작성 중인 회고가 저장되지 않았습니다. 홈으로 이동하시겠어요?');
-    //   if (!proceed) return;
-    // }
+  // 임시 저장 처리 함수
+  const handleTempSave = async () => {
+    if (isRefreshing) return;
 
+    if (hasChanges()) {
+      try {
+        if (lastSubmittedAnswers.length === 0) {
+          // 임시저장 처음 하는 경우
+          await updateAllAnswersMutation.mutateAsync({ data: { answers } });
+        } else {
+          // 이후 임시저장
+          const changed = answers.filter((a) => {
+            const prev = lastSubmittedAnswers.find((p) => p.answerId === a.answerId);
+            return !prev || prev.content !== a.content;
+          });
+          if (changed.length > 0) {
+            await Promise.all(
+              changed.map((ans) =>
+                updateAnswerMutation.mutateAsync({
+                  answerId: ans.answerId,
+                  data: { content: ans.content },
+                }),
+              ),
+            );
+          }
+        }
+      } catch (error) {
+        console.error('임시 저장 실패', error);
+      }
+    }
     router.push('/', { scroll: true });
   };
 
@@ -149,7 +164,7 @@ export default function FixedFooter({
     >
       <div className={'flex items-center gap-4'}>
         <AutoSaveStatus status={autoSaveStatus} />
-        <Button variant={'outlineGrey'} size={'medium'} onClick={handleGoHome}>
+        <Button variant={'outlineGrey'} size={'medium'} onClick={handleTempSave}>
           {'임시 저장'}
         </Button>
         <Button

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -137,7 +137,7 @@ export default function FixedFooter({
         await saveAnswers();
         router.push('/', { scroll: true });
       } catch {
-        // toast 필요 부분
+        // TODO : 토스트 메시지 표시 (예: "저장에 실패했습니다. 다시 시도해주세요.")
       } finally {
         setIsTempSaving(false);
       }

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -40,6 +40,7 @@ export default function FixedFooter({
   const markPRAsDoneMutation = useMarkPRAsDoneMutation();
   const queryClient = useQueryClient();
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isTempSaving, setIsTempSaving] = useState(false);
   const router = useRouter();
 
   const hasChanges = () => {
@@ -55,15 +56,42 @@ export default function FixedFooter({
     });
   };
 
+  // 공통 저장 로직 함수
+  const saveAnswers = async () => {
+    if (lastSubmittedAnswers.length === 0) {
+      // 첫 저장
+      await updateAllAnswersMutation.mutateAsync({ data: { answers } });
+      setLastSubmittedAnswers([...answers]);
+    } else {
+      // 변경된 답변만 저장
+      const changed = answers.filter((a) => {
+        const prev = lastSubmittedAnswers.find((p) => p.answerId === a.answerId);
+        return !prev || prev.content !== a.content;
+      });
+      if (changed.length > 0) {
+        await Promise.all(
+          changed.map((ans) =>
+            updateAnswerMutation.mutateAsync({
+              answerId: ans.answerId,
+              data: { content: ans.content },
+            }),
+          ),
+        );
+        setLastSubmittedAnswers([...answers]);
+      }
+    }
+  };
+
+  // 저장 처리 함수
   const handleComplete = async () => {
     if (isRefreshing) return;
 
-    // 변경사항이 없으면 fetch 보내지 않음
+    // 변경사항이 없는 경우
     if (isCompleted && !hasChanges()) {
       return;
     }
 
-    // answerId가 없는 값이 있으면 요청을 보내지 않음
+    // answerId가 없는 값이 있는 경우
     const invalidAnswers = answers.filter((a) => typeof a.answerId !== 'number' || Number.isNaN(a.answerId));
     if (invalidAnswers.length > 0) {
       return;
@@ -81,28 +109,7 @@ export default function FixedFooter({
     }
 
     try {
-      if (lastSubmittedAnswers.length === 0) {
-        // First submit 처리
-        await updateAllAnswersMutation.mutateAsync({ data: { answers } });
-        setLastSubmittedAnswers([...answers]);
-      } else {
-        // Subsequent submit 처리
-        const changed = answers.filter((a) => {
-          const prev = lastSubmittedAnswers.find((p) => p.answerId === a.answerId);
-          return !prev || prev.content !== a.content;
-        });
-        if (changed.length > 0) {
-          await Promise.all(
-            changed.map((ans) =>
-              updateAnswerMutation.mutateAsync({
-                answerId: ans.answerId,
-                data: { content: ans.content },
-              }),
-            ),
-          );
-          setLastSubmittedAnswers([...answers]);
-        }
-      }
+      await saveAnswers();
 
       // 완료되지 않은 상태에서만 markPRAsDone 호출
       if (!isCompleted) {
@@ -110,50 +117,33 @@ export default function FixedFooter({
       }
 
       setIsRefreshing(true);
-      // refetch 서버 데이터
       await queryClient.refetchQueries({ queryKey: ['pullRequestDetail', Number(pullRequestId)] });
       setIsRefreshing(false);
       if (onComplete) onComplete();
 
-      // 홈으로 리다이렉트
       router.push('/', { scroll: true });
-    } catch (error) {
-      console.error('회고 완료 실패', error);
+    } catch {
       setIsRefreshing(false);
     }
   };
 
   // 임시 저장 처리 함수
   const handleTempSave = async () => {
-    if (isRefreshing) return;
+    if (isRefreshing || isTempSaving) return;
 
     if (hasChanges()) {
+      setIsTempSaving(true);
       try {
-        if (lastSubmittedAnswers.length === 0) {
-          // 임시저장 처음 하는 경우
-          await updateAllAnswersMutation.mutateAsync({ data: { answers } });
-        } else {
-          // 이후 임시저장
-          const changed = answers.filter((a) => {
-            const prev = lastSubmittedAnswers.find((p) => p.answerId === a.answerId);
-            return !prev || prev.content !== a.content;
-          });
-          if (changed.length > 0) {
-            await Promise.all(
-              changed.map((ans) =>
-                updateAnswerMutation.mutateAsync({
-                  answerId: ans.answerId,
-                  data: { content: ans.content },
-                }),
-              ),
-            );
-          }
-        }
-      } catch (error) {
-        console.error('임시 저장 실패', error);
+        await saveAnswers();
+        router.push('/', { scroll: true });
+      } catch {
+        // toast 필요 부분
+      } finally {
+        setIsTempSaving(false);
       }
+    } else {
+      router.push('/', { scroll: true });
     }
-    router.push('/', { scroll: true });
   };
 
   return (
@@ -166,8 +156,13 @@ export default function FixedFooter({
         <AutoSaveStatus status={autoSaveStatus} />
         {!isCompleted ? (
           <>
-            <Button variant={'outlineGrey'} size={'medium'} onClick={handleTempSave}>
-              {'임시 저장'}
+            <Button
+              variant={'outlineGrey'}
+              size={'medium'}
+              onClick={handleTempSave}
+              disabled={isTempSaving || isRefreshing}
+            >
+              {isTempSaving ? '저장 중...' : '임시 저장'}
             </Button>
             <Button
               variant={'filledPrimary'}
@@ -178,7 +173,8 @@ export default function FixedFooter({
                 updateAllAnswersMutation.isPending ||
                 updateAnswerMutation.isPending ||
                 markPRAsDoneMutation.isPending ||
-                isRefreshing
+                isRefreshing ||
+                isTempSaving
               }
             >
               {isRefreshing ? '새로고침 중...' : '회고 완료'}
@@ -193,7 +189,8 @@ export default function FixedFooter({
               answers.length === 0 ||
               updateAllAnswersMutation.isPending ||
               updateAnswerMutation.isPending ||
-              isRefreshing
+              isRefreshing ||
+              isTempSaving
             }
           >
             {isRefreshing ? '새로고침 중...' : '저장'}


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

Closes #139 

- 홈으로 버튼 삭제 + (회고 완료 | 임시저장) 으로 구성하기  
  - PR이 회고 중일 때 → [회고 완료 | 임시 저장] (회고 완료 → 리다이렉트, 임시 저장 → 리다이렉트)
  - PR이 회고 완료일 때 → [ 저장 ] (저장 → 리다이렉트)

### 회고 중일때 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c7843617-2fc9-4f0f-bdab-6bc64c6d2bd3" />

### 회고 완료일때 
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/0c4087b2-8b70-4ea3-b67f-1a2b97bab7bc" />


## Why?

- UT 결과에서 다음 문제가 확인되었습니다. 
1) 회고 페이지에서 홈으로 이동하는 경로가 명확하지 않음
2) `회고 전 / 회고 중 / 회고 완료` 상태 구분이 직관적이지 않음
3) 임시 저장 기능이 없어 사용자가 중간 진행 내용을 보존할 수 없음


## How?

- 버튼 구조 및 상태별 동작 로직을 위 조건에 맞게 수정하여, 사용 흐름의 명확성과 편의성을 개선하였습니다.

## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 임시 저장(자동 저장 유사) 추가: 최초 저장은 전체 저장, 이후 변경된 답변만 저장하며 동시 저장 방지.
  * 임시 저장 후 홈 이동 처리 추가(성공/실패 시 리다이렉트 유지).
  * 완료 흐름에서 먼저 저장 후 완료 처리 및 데이터 재조회로 저장 로직 통합.

* 리팩터링
  * 풋터 액션 바 개선: 미완료 시 ‘임시 저장’·‘회고 완료’, 완료 시 ‘저장’만 표시.
  * 저장/갱신 상태에 따른 버튼 비활성화 및 로딩 텍스트 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->