### PR TITLE
refactor: 랜딩 페이지 접근성 개선

### DIFF
--- a/src/components/common/LoadingButton.tsx
+++ b/src/components/common/LoadingButton.tsx
@@ -47,8 +47,9 @@ export function LoadingButton({
       disabled={isPending}
       type={type}
       className={cn('transition-colors duration-200', className)}
+      aria-busy={isPending}
     >
-      <span ref={textRef} style={{ width: isPending ? `${width}px` : 'auto' }}>
+      <span ref={textRef} style={{ width: isPending ? `${width}px` : 'auto' }} aria-live={'polite'}>
         {isPending ? <ShinyText text={'로딩중...'} disabled={false} speed={2} /> : children}
       </span>
     </Button>

--- a/src/components/common/Tabs/TabsContent.tsx
+++ b/src/components/common/Tabs/TabsContent.tsx
@@ -1,22 +1,21 @@
 'use client';
 
-import { ReactNode } from 'react';
+import { HTMLProps, ReactNode } from 'react';
 
 import { useTabsContext } from '@/providers/TabsContext';
 
-interface TabsContentProps {
+interface TabsContentProps extends HTMLProps<HTMLDivElement> {
   value: string;
   children: ReactNode;
-  className?: string;
 }
 
-export default function TabsContent({ value, children, className = '' }: TabsContentProps) {
+export default function TabsContent({ value, children, className = '', ...props }: TabsContentProps) {
   const { activeTab } = useTabsContext();
 
   if (activeTab !== value) return null;
 
   return (
-    <div role={'tabpanel'} className={className}>
+    <div role={'tabpanel'} className={className} {...props}>
       {children}
     </div>
   );

--- a/src/components/landing/FeatureCard.tsx
+++ b/src/components/landing/FeatureCard.tsx
@@ -5,10 +5,11 @@ import FeatureCardGradient from '@/assets/svg/feature-card-gradient.svg';
 
 interface FeatureCardProps {
   image: StaticImageData;
+  alt: string;
   children: ReactNode;
 }
 
-export default function FeatureCard({ image, children }: FeatureCardProps) {
+export default function FeatureCard({ image, alt, children }: FeatureCardProps) {
   return (
     <div
       className={
@@ -17,7 +18,7 @@ export default function FeatureCard({ image, children }: FeatureCardProps) {
     >
       <FeatureCardGradient className={'absolute'} />
       <div className={'flex h-full flex-col justify-between p-6'}>
-        <Image src={image} alt={'Landing Symbol 1'} width={100} />
+        <Image src={image} alt={alt} width={100} />
         <div className={'flex flex-col gap-4 font-medium max-md:gap-3'}>{children}</div>
       </div>
     </div>

--- a/src/components/landing/LandingNavigation.tsx
+++ b/src/components/landing/LandingNavigation.tsx
@@ -24,7 +24,7 @@ export default function LandingNavigation({ className }: LandingNavigationProps)
         className,
       )}
     >
-      <Link href={'/'} className={'text-h4 font-bold'}>
+      <Link href={'/'} aria-label={'홈으로'} className={'text-h4 font-bold'}>
         <Logo />
       </Link>
       <LoadingButton variant={'filledPrimary'} size={'small'} action={handleLogin}>

--- a/src/components/landing/LandingNavigation.tsx
+++ b/src/components/landing/LandingNavigation.tsx
@@ -24,8 +24,8 @@ export default function LandingNavigation({ className }: LandingNavigationProps)
         className,
       )}
     >
-      <Link href={'/'} aria-label={'홈으로'} className={'text-h4 font-bold'}>
-        <Logo />
+      <Link href={'/'} className={'text-h4 font-bold'}>
+        <Logo aria-label={'홈 이동'} />
       </Link>
       <LoadingButton variant={'filledPrimary'} size={'small'} action={handleLogin}>
         {'시작하기'}

--- a/src/components/landing/Section/FeatureSection.tsx
+++ b/src/components/landing/Section/FeatureSection.tsx
@@ -14,11 +14,11 @@ export default function FeatureSection() {
               {'주요 기능'}
             </Tag>
             <div className={'flex flex-col items-center text-center'}>
-              <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>
+              <h2 className={'blue-tiny-right text-landing-title inline-block font-bold'}>
                 {'회고, 더는 어렵지 않아요.'}
                 <br />
                 {'Devoops가 다 챙겨줄게요.'}
-              </h1>
+              </h2>
             </div>
           </div>
           <div className={'text-dark-grey-600 text-landing-content text-center font-medium'}>
@@ -29,7 +29,7 @@ export default function FeatureSection() {
       <div className={'mt-[38px] mb-[72px] flex flex-col items-center'}>
         <div className={'flex items-center gap-3 max-md:w-full max-md:flex-col'}>
           <FeatureCard image={LandingSymbol1} alt={''}>
-            <h2 className={'text-h3'}>{'레포지토리 연동'}</h2>
+            <h3 className={'text-h3'}>{'레포지토리 연동'}</h3>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>
                 <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
@@ -41,7 +41,7 @@ export default function FeatureSection() {
             </div>
           </FeatureCard>
           <FeatureCard image={LandingSymbol2} alt={''}>
-            <h2 className={'text-h3'}>{'회고를 돕는 AI'}</h2>
+            <h3 className={'text-h3'}>{'회고를 돕는 AI'}</h3>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>
                 <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
@@ -58,7 +58,7 @@ export default function FeatureSection() {
             </div>
           </FeatureCard>
           <FeatureCard image={LandingSymbol3} alt={''}>
-            <h2 className={'text-h3'}>{'질문만 답해서 완료!'}</h2>
+            <h3 className={'text-h3'}>{'질문만 답해서 완료!'}</h3>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>{'부담 없이 한 줄씩 적다 보면'}</p>
               <p className={'text-h5 max-md:text-body-medium'}>

--- a/src/components/landing/Section/FeatureSection.tsx
+++ b/src/components/landing/Section/FeatureSection.tsx
@@ -29,7 +29,7 @@ export default function FeatureSection() {
       <div className={'mt-[38px] mb-[72px] flex flex-col items-center'}>
         <div className={'flex items-center gap-3 max-md:w-full max-md:flex-col'}>
           <FeatureCard image={LandingSymbol1} alt={''}>
-            <h3 className={'text-h3'}>{'레포지토리 연동'}</h3>
+            <h2 className={'text-h3'}>{'레포지토리 연동'}</h2>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>
                 <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
@@ -41,7 +41,7 @@ export default function FeatureSection() {
             </div>
           </FeatureCard>
           <FeatureCard image={LandingSymbol2} alt={''}>
-            <h3 className={'text-h3'}>{'회고를 돕는 AI'}</h3>
+            <h2 className={'text-h3'}>{'회고를 돕는 AI'}</h2>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>
                 <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
@@ -58,7 +58,7 @@ export default function FeatureSection() {
             </div>
           </FeatureCard>
           <FeatureCard image={LandingSymbol3} alt={''}>
-            <h3 className={'text-h3'}>{'질문만 답해서 완료!'}</h3>
+            <h2 className={'text-h3'}>{'질문만 답해서 완료!'}</h2>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>{'부담 없이 한 줄씩 적다 보면'}</p>
               <p className={'text-h5 max-md:text-body-medium'}>

--- a/src/components/landing/Section/FeatureSection.tsx
+++ b/src/components/landing/Section/FeatureSection.tsx
@@ -16,8 +16,9 @@ export default function FeatureSection() {
             <div className={'flex flex-col items-center text-center'}>
               <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>
                 {'회고, 더는 어렵지 않아요.'}
+                <br />
+                {'Devoops가 다 챙겨줄게요.'}
               </h1>
-              <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>{'Devoops가 다 챙겨줄게요.'}</h1>
             </div>
           </div>
           <div className={'text-dark-grey-600 text-landing-content text-center font-medium'}>
@@ -27,7 +28,7 @@ export default function FeatureSection() {
       </div>
       <div className={'mt-[38px] mb-[72px] flex flex-col items-center'}>
         <div className={'flex items-center gap-3 max-md:w-full max-md:flex-col'}>
-          <FeatureCard image={LandingSymbol1}>
+          <FeatureCard image={LandingSymbol1} alt={''}>
             <h3 className={'text-h3'}>{'레포지토리 연동'}</h3>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>
@@ -39,7 +40,7 @@ export default function FeatureSection() {
               <p>{'회고할 작업을 한눈에 확인할 수 있어요.'}</p>
             </div>
           </FeatureCard>
-          <FeatureCard image={LandingSymbol2}>
+          <FeatureCard image={LandingSymbol2} alt={''}>
             <h3 className={'text-h3'}>{'회고를 돕는 AI'}</h3>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>
@@ -56,7 +57,7 @@ export default function FeatureSection() {
               </p>
             </div>
           </FeatureCard>
-          <FeatureCard image={LandingSymbol3}>
+          <FeatureCard image={LandingSymbol3} alt={''}>
             <h3 className={'text-h3'}>{'질문만 답해서 완료!'}</h3>
             <div className={'max-md:text-body-medium'}>
               <p className={'text-h5 max-md:text-body-medium'}>{'부담 없이 한 줄씩 적다 보면'}</p>

--- a/src/components/landing/Section/FooterCTA.tsx
+++ b/src/components/landing/Section/FooterCTA.tsx
@@ -12,9 +12,9 @@ export default function FooterCTA({ action }: FooterCTAProps) {
           'mx-auto mb-[48px] flex items-center justify-center gap-8 py-[96px] max-lg:flex-col max-lg:text-center'
         }
       >
-        <h1 className={'text-h1 blue-tiny-right inline-block leading-[58px] font-bold max-lg:text-h2'}>
+        <h2 className={'text-h1 blue-tiny-right inline-block leading-[58px] font-bold max-lg:text-h2'}>
           {'복잡한 회고, Devoops가 슬쩍 정리해줄게요.'}
-        </h1>
+        </h2>
         <LoadingButton variant={'filledPrimary'} size={'medium'} action={action}>
           {'Devoops 시작하기'}
         </LoadingButton>

--- a/src/components/landing/Section/HeroSection.tsx
+++ b/src/components/landing/Section/HeroSection.tsx
@@ -13,7 +13,7 @@ export default function HeroSection({ action }: HeroSectionProps) {
       <div className={'mt-[144px] flex flex-col items-center gap-7'}>
         <div>
           <div className={'mb-4.5 flex flex-col items-center text-center'}>
-            <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>
+            <h1 className={'blue-tiny-right text-landing-title inline-block font-bold'}>
               {'코드는 남았는데 '}
               <br />
               {'고민은 사라졌다면...?'}

--- a/src/components/landing/Section/HeroSection.tsx
+++ b/src/components/landing/Section/HeroSection.tsx
@@ -13,8 +13,11 @@ export default function HeroSection({ action }: HeroSectionProps) {
       <div className={'mt-[144px] flex flex-col items-center gap-7'}>
         <div>
           <div className={'mb-4.5 flex flex-col items-center text-center'}>
-            <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>{'코드는 남았는데'}</h1>
-            <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>{'고민은 사라졌다면...?'}</h1>
+            <h1 className={'blue-tiny-right text-landing-h1 inline-block font-bold'}>
+              {'코드는 남았는데 '}
+              <br />
+              {'고민은 사라졌다면...?'}
+            </h1>
           </div>
           <div className={'text-dark-grey-600 text-landing-content flex flex-col text-center font-medium'}>
             <p>
@@ -41,7 +44,7 @@ export default function HeroSection({ action }: HeroSectionProps) {
           'border-dark-grey-200 shadow-landing-image mx-auto mt-[67px] max-w-[1000px] overflow-hidden rounded-tl-[28px] rounded-tr-[28px] border-1 max-md:rounded-tl-[20px] max-md:rounded-tr-[20px]'
         }
       >
-        <Image src={LandingHero} alt={'Landing Hero'} priority />
+        <Image src={LandingHero} alt={'Devoops 웹페이지의 기능 요약을 보여주는 스크린샷'} priority />
       </div>
     </section>
   );

--- a/src/components/landing/Section/RepolinkSection.tsx
+++ b/src/components/landing/Section/RepolinkSection.tsx
@@ -32,7 +32,7 @@ export default function RepolinkSection() {
           'border-dark-grey-200 bg-gradient-landing-image mx-auto mt-[78px] max-w-[1000px] overflow-hidden rounded-tl-[28px] rounded-tr-[28px] border-1 pt-[53px] pb-[38px] max-md:pt-[13px]'
         }
       >
-        <Image src={RepolinkImage} alt={'Landing Hero'} width={508} className={'mx-auto'} />
+        <Image src={RepolinkImage} alt={'회고할 레포지토리를 입력하는 시연 이미지'} width={508} className={'mx-auto'} />
       </div>
     </section>
   );

--- a/src/components/landing/Section/RepolinkSection.tsx
+++ b/src/components/landing/Section/RepolinkSection.tsx
@@ -12,9 +12,9 @@ export default function RepolinkSection() {
             <Tag dotColor={'primary'} size={'medium'} padding={'medium'}>
               {'AI를 통한 간편한 회고'}
             </Tag>
-            <h1 className={'blue-tiny-right text-landing-h1 inline-block text-center font-bold'}>
+            <h2 className={'blue-tiny-right text-landing-title inline-block text-center font-bold'}>
               {'레포 주소만 입력하면. 끝'}
-            </h1>
+            </h2>
           </div>
           <div className={'text-dark-grey-600 flex flex-col text-center text-[18px] leading-[29px] font-medium'}>
             <p>

--- a/src/components/landing/Section/StartSection.tsx
+++ b/src/components/landing/Section/StartSection.tsx
@@ -14,9 +14,9 @@ export default function StartSection() {
           <Tag dotColor={'primary'} size={'medium'} padding={'medium'}>
             {'AI를 통한 간편한 회고'}
           </Tag>
-          <h1 className={'blue-tiny-right text-landing-h1 inline-block text-center font-bold'}>
+          <h2 className={'blue-tiny-right text-landing-title inline-block text-center font-bold'}>
             {'Devoops로 회고를 시작해볼까요?'}
-          </h1>
+          </h2>
         </div>
         <div>
           <Tabs defaultValue={'PR 요약'}>

--- a/src/components/landing/Section/StartSection.tsx
+++ b/src/components/landing/Section/StartSection.tsx
@@ -22,15 +22,30 @@ export default function StartSection() {
           <Tabs defaultValue={'PR 요약'}>
             <div className={'flex items-center justify-center'}>
               <TabsList>
-                <TabsTrigger value={'PR 요약'}>{'PR 요약'}</TabsTrigger>
-                <TabsTrigger value={'회고 질문 제공'}>{'회고 질문 제공'}</TabsTrigger>
-                <TabsTrigger value={'회고 답변'}>{'회고 답변'}</TabsTrigger>
+                <TabsTrigger value={'PR 요약'} id={'tab-pr-summary'} aria-controls={'panel-pr-summary'}>
+                  {'PR 요약'}
+                </TabsTrigger>
+                <TabsTrigger
+                  value={'회고 질문 제공'}
+                  id={'tab-retrospective-question'}
+                  aria-controls={'panel-retrospective-question'}
+                >
+                  {'회고 질문 제공'}
+                </TabsTrigger>
+                <TabsTrigger
+                  value={'회고 답변'}
+                  id={'tab-retrospective-answer'}
+                  aria-controls={'panel-retrospective-answer'}
+                >
+                  {'회고 답변'}
+                </TabsTrigger>
               </TabsList>
             </div>
             <div>
               <TabsContent
                 value={'PR 요약'}
-                aria-label={'PR summary'}
+                id={'panel-pr-summary'}
+                aria-labelledby={'tab-pr-summary'}
                 className={'flex flex-col items-center gap-[30px] pt-[36px]'}
               >
                 <div className={'text-body-large text-dark-grey-600 flex flex-col text-center font-medium'}>
@@ -52,7 +67,8 @@ export default function StartSection() {
               </TabsContent>
               <TabsContent
                 value={'회고 질문 제공'}
-                aria-label={'Retrospective question'}
+                id={'panel-retrospective-question'}
+                aria-labelledby={'tab-retrospective-question'}
                 className={'flex flex-col items-center gap-[30px] pt-[36px] pb-[48px]'}
               >
                 <div className={'text-body-large text-dark-grey-600 flex flex-col text-center font-medium'}>
@@ -79,7 +95,8 @@ export default function StartSection() {
               </TabsContent>
               <TabsContent
                 value={'회고 답변'}
-                aria-label={'Retrospective answer'}
+                id={'panel-retrospective-answer'}
+                aria-labelledby={'tab-retrospective-answer'}
                 className={'flex flex-col items-center gap-[30px] pt-[36px] pb-[48px]'}
               >
                 <div className={'text-body-large text-dark-grey-600 flex flex-col text-center font-medium'}>

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -92,7 +92,7 @@
   line-height: var(--leading-caption);
 }
 
-@utility text-landing-h1 {
+@utility text-landing-title {
   font-size: 48px;
   line-height: 64px;
 


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?
close #149 

랜딩 페이지의 접근성을 개선 했습니다.

주로 다음과 같은 작업을 수행했습니다.
- 불필요한 alt 값 제거, alt 값 명확하게 부여
- 명확한 heading tag 계층화
- `aria-busy`를 통한 로딩 상태 전달 및 `aria-live`를 통한 상태 전환 시 알림
- TabsTrigger와 TabsContent 요소간 연결

(15기 웹 접근성 마스터 @Pridesd 형님 리뷰 한 번만..☺️🙇🏻‍♂️)

## Why?

- 웹 콘텐츠 접근성을 높이기 위함입니다.

## How?

lighthouse 접근성 접근성 점수를 90점 -> 96점으로 개선할 수 있었습니다.

|<img width="764" height="816" alt="스크린샷 2025-10-12 오후 5 46 56" src="https://github.com/user-attachments/assets/4ff54c46-ebf1-46b6-8cbf-361ce3d6d695" />|<img width="764" height="624" alt="스크린샷 2025-10-12 오후 5 50 19" src="https://github.com/user-attachments/assets/be80d00c-754b-4058-b12f-60f4b163c65e" />|
|:---:|:---:|
| 개선 전 90점 | 개선 후 96점 |


### 다음과 같은 이슈가 남아있었습니다.

> 백그라운드 및 포그라운드 색상의 대비율이 충분하지 않습니다

해당 접근성 문제는 버튼의 background color와 foreground color의 대비값이 `4.5:1` 을 준수하지 못했기 때문입니다.

|<img width="797" height="180" alt="스크린샷 2025-10-12 오후 5 55 18" src="https://github.com/user-attachments/assets/34e1cb2e-76a3-45b4-8307-e2f76c1aa8be" />|<img width="463" height="848" alt="스크린샷 2025-10-12 오후 5 22 06" src="https://github.com/user-attachments/assets/8c1a5959-f389-472f-bcda-4c87184ea376" />|
|:---:|:---:|
| [성공 기준](https://dequeuniversity.com/rules/axe/4.10/color-contrast) | 현재 버튼 컬러의 대비값은 `3.9:1` 임|

다만 primary color 값을 임의로 수정하기에는 무리가 있다 판단되어서 해당 문제는 남겨두었습니다.

|<img width="576" height="110" alt="스크린샷 2025-10-12 오후 8 24 45" src="https://github.com/user-attachments/assets/d502e610-2851-4028-97b3-cde9dc992a40" />|
|:---:|
| 위 사항 개선 시 |

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 접근성 강화: 로딩 버튼의 상태 안내(스크린리더), 탭 트리거-패널 ARIA 연결 보강, 홈 링크 로고에 라벨 추가, 이미지 대체 텍스트 개선 및 기능 카드에 alt 지원.
* **Style**
  * 랜딩 헤딩 계층 조정(여러 섹션 h1→h2), 타이포그래피 유틸리티명 변경 및 레이아웃/가독성 정리.
* **Chores**
  * 탭 콘텐츠에 추가 HTML 속성 전파 지원으로 유연성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->