### PR TITLE
chore: [회고] 선택된 질문들에 대해 카테고리 표기해주기

### DIFF
--- a/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
@@ -138,11 +138,17 @@ export default function RetrospectivePage() {
   );
 
   const selectedQuestions = groupedQuestions
-    ?.flatMap((categoryItem) => categoryItem.questions)
+    ?.flatMap((categoryItem) =>
+      categoryItem.questions.map((q) => ({
+        category: categoryItem.category,
+        ...q,
+      })),
+    )
     ?.filter((q) => selectedQuestionIds.includes(q.questionId))
     ?.map((q) => ({
       questionId: q.questionId,
       content: q.question,
+      category: q.category,
       answer: null,
     }));
 

--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -89,9 +89,11 @@ export default function RetrospectiveAnswers({
                 className={'bg-dark-grey-50 relative flex flex-col gap-[8px] rounded-[8px] px-[24px] py-[20px]'}
               >
                 {question.category && (
-                  <Tag dotColor={getCategoryColor()} size={'small'}>
-                    {question.category}
-                  </Tag>
+                  <div className={'w-fit'}>
+                    <Tag dotColor={getCategoryColor()} size={'small'}>
+                      {question.category}
+                    </Tag>
+                  </div>
                 )}
 
                 <div className={'flex items-center justify-between'}>

--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -88,10 +88,15 @@ export default function RetrospectiveAnswers({
                 }}
                 className={'bg-dark-grey-50 relative flex flex-col gap-[8px] rounded-[8px] px-[24px] py-[20px]'}
               >
+                {question.category && (
+                  <Tag dotColor={getCategoryColor()} size={'small'}>
+                    {question.category}
+                  </Tag>
+                )}
+
                 <div className={'flex items-center justify-between'}>
                   <div className={'flex items-center gap-3'}>
                     <p className={'text-body-medium font-semibold break-all'}>{question.content}</p>
-                    {question.category && <Tag dotColor={getCategoryColor()}>{question.category}</Tag>}
                   </div>
                   {onDeleteAnswer && (
                     <button

--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -5,11 +5,13 @@ import React, { useRef, useEffect, useState } from 'react';
 import EditButtonIcon from '@/components/common/icons/EditButtonIcon';
 import PenIcon from '@/components/common/icons/PenIcon';
 import WarningIcon from '@/components/common/icons/WarningIcon';
+import Tag from '@/components/common/Tag';
 import AnswerEditor, { EditorTab } from '@/components/retrospective/AnswerEditor';
 import SectionHeader from '@/components/retrospective/SectionHeader';
+import { getCategoryColor } from '@/utils/getTagColor';
 
 interface RetrospectiveAnswersProps {
-  selectedQuestions: { questionId: number; content: string }[];
+  selectedQuestions: { questionId: number; content: string; category?: string }[];
   // eslint-disable-next-line react/no-unused-prop-types
   answers: { answerId: number; questionId: number; content: string }[];
   getAnswerContent: (questionId: number) => string;
@@ -87,7 +89,10 @@ export default function RetrospectiveAnswers({
                 className={'bg-dark-grey-50 relative flex flex-col gap-[8px] rounded-[8px] px-[24px] py-[20px]'}
               >
                 <div className={'flex items-center justify-between'}>
-                  <p className={'text-body-medium font-semibold break-all'}>{question.content}</p>
+                  <div className={'flex items-center gap-3'}>
+                    <p className={'text-body-medium font-semibold break-all'}>{question.content}</p>
+                    {question.category && <Tag dotColor={getCategoryColor()}>{question.category}</Tag>}
+                  </div>
                   {onDeleteAnswer && (
                     <button
                       type={'button'}

--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -8,7 +8,7 @@ import WarningIcon from '@/components/common/icons/WarningIcon';
 import Tag from '@/components/common/Tag';
 import AnswerEditor, { EditorTab } from '@/components/retrospective/AnswerEditor';
 import SectionHeader from '@/components/retrospective/SectionHeader';
-import { getCategoryColor } from '@/utils/getTagColor';
+import { CATEGORY_COLOR } from '@/constants/colors';
 
 interface RetrospectiveAnswersProps {
   selectedQuestions: { questionId: number; content: string; category?: string }[];
@@ -90,7 +90,7 @@ export default function RetrospectiveAnswers({
               >
                 {question.category && (
                   <div className={'w-fit'}>
-                    <Tag dotColor={getCategoryColor()} size={'small'}>
+                    <Tag dotColor={CATEGORY_COLOR} size={'small'}>
                       {question.category}
                     </Tag>
                   </div>

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,0 +1,1 @@
+export const CATEGORY_COLOR = 'lime';

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -27,6 +27,3 @@ export const getTagColor = (tagName: string) => {
   const foundTag = findMatchingTag(tagName);
   return tagColors[foundTag];
 };
-
-// 회고페이지 -  질문 카테고리 색상
-export const getCategoryColor = (): TagDotColor => 'lime';

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -29,4 +29,4 @@ export const getTagColor = (tagName: string) => {
 };
 
 // 회고페이지 -  질문 카테고리 색상
-export const getCategoryColor = (): TagDotColor => 'gray';
+export const getCategoryColor = (): TagDotColor => 'lime';

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -27,3 +27,6 @@ export const getTagColor = (tagName: string) => {
   const foundTag = findMatchingTag(tagName);
   return tagColors[foundTag];
 };
+
+// 회고페이지 -  질문 카테고리 색상
+export const getCategoryColor = () => 'gray';

--- a/src/utils/getTagColor.ts
+++ b/src/utils/getTagColor.ts
@@ -29,4 +29,4 @@ export const getTagColor = (tagName: string) => {
 };
 
 // 회고페이지 -  질문 카테고리 색상
-export const getCategoryColor = () => 'gray';
+export const getCategoryColor = (): TagDotColor => 'gray';


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #148

- 회고 답변 페이지에서 선택된 질문들에 대해 카테고리 태그를 표시하도록 개선하였습니다. 

<img height="250" alt="image" src="https://github.com/user-attachments/assets/9d6ebaf9-1f9b-4242-b7ff-a50bc798acae" />
<img height="250" alt="image" src="https://github.com/user-attachments/assets/a85f0399-2675-4766-b94a-50029cf1d874" />


## Why?

- 사용자가 선택한 질문의 카테고리를 한눈에 파악할 수 있도록 하면 회고 작성 시 맥락을 더 잘 이해할 수 있을 것이라고 생각하였습니다. 

## How?

- `getCategoryColor()` 함수로 태그 생성 → RetrospectiveAnswers.tsx에서 태그 표시

## Check List

- [X] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 회고 답변 화면에서 각 질문 옆에 카테고리 태그가 표시됩니다(해당되는 경우). 태그에는 작은 라임 색상 점이 포함되어 질문 분류를 한눈에 파악할 수 있습니다.
* 스타일
  * 새 태그 표시를 위해 콘텐츠 영역을 감싸는 레이아웃을 소폭 조정하고 주변 간격을 추가했습니다. 전체 구조와 흐름은 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->