### PR TITLE
style: 회고 페이지 카테고리 탭 스타일 변경 (main페이지와 통일)

### DIFF
--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -5,10 +5,8 @@ import React, { useRef, useEffect, useState } from 'react';
 import EditButtonIcon from '@/components/common/icons/EditButtonIcon';
 import PenIcon from '@/components/common/icons/PenIcon';
 import WarningIcon from '@/components/common/icons/WarningIcon';
-import Tag from '@/components/common/Tag';
 import AnswerEditor, { EditorTab } from '@/components/retrospective/AnswerEditor';
 import SectionHeader from '@/components/retrospective/SectionHeader';
-import { CATEGORY_COLOR } from '@/constants/colors';
 
 interface RetrospectiveAnswersProps {
   selectedQuestions: { questionId: number; content: string; category?: string }[];
@@ -89,13 +87,8 @@ export default function RetrospectiveAnswers({
                 className={'bg-dark-grey-50 relative flex flex-col gap-[8px] rounded-[8px] px-[24px] py-[20px]'}
               >
                 {question.category && (
-                  <div className={'w-fit'}>
-                    <Tag dotColor={CATEGORY_COLOR} size={'small'}>
-                      {question.category}
-                    </Tag>
-                  </div>
+                  <div className={'text-body-small text-dark-blue-700 font-semibold'}>{question.category}</div>
                 )}
-
                 <div className={'flex items-center justify-between'}>
                   <div className={'flex items-center gap-3'}>
                     <p className={'text-body-medium font-semibold break-all'}>{question.content}</p>


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- 회고 페이지의 질문 박스에 표시되는 카테고리 스타일을 메인 페이지와 동일한 방식으로 통일하였습니다.
<img width="1188" height="743" alt="image" src="https://github.com/user-attachments/assets/fd061640-ac7d-4449-bb96-54a4189c341b" />


## Why?

- 

## How?

- 

## Check List

- [X] Merge 할 브랜치가 올바른가?
