### PR TITLE
feat: 페이지네이션 URL 쿼리 파라미터 추가

### DIFF
--- a/src/components/home/MyPRContent.tsx
+++ b/src/components/home/MyPRContent.tsx
@@ -35,7 +35,7 @@ export function MyPRContent({ initRepositories, currentTab }: MyPRContentProps) 
     setCurrentPage(initPage);
 
     setActiveTab(currentTab);
-  }, [currentTab]);
+  }, [currentTab, searchParams]);
 
   const handleTabChange = (tabValue: string) => {
     const params = new URLSearchParams(searchParams);

--- a/src/components/home/MyPRContent.tsx
+++ b/src/components/home/MyPRContent.tsx
@@ -15,20 +15,37 @@ interface MyPRContentProps {
   currentTab: string;
 }
 
+function getInitPageFromParams(searchParams: URLSearchParams) {
+  const pageParam = searchParams.get('page');
+  const urlPageValue = parseInt(pageParam || '0', 10) || 0;
+  const initPage = urlPageValue > 0 ? urlPageValue - 1 : 0;
+
+  return initPage;
+}
+
 export function MyPRContent({ initRepositories, currentTab }: MyPRContentProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
 
   const [activeTab, setActiveTab] = useState(currentTab);
+  const [currentPage, setCurrentPage] = useState<number>(0);
 
   useEffect(() => {
+    const initPage = getInitPageFromParams(searchParams);
+    setCurrentPage(initPage);
+
     setActiveTab(currentTab);
   }, [currentTab]);
 
   const handleTabChange = (tabValue: string) => {
     const params = new URLSearchParams(searchParams);
+
     setActiveTab(tabValue);
     params.set('tab', tabValue);
+
+    setCurrentPage(0);
+    params.set('page', '1');
+
     router.push(`?${params.toString()}`, { scroll: false });
   };
 
@@ -52,7 +69,7 @@ export function MyPRContent({ initRepositories, currentTab }: MyPRContentProps) 
         </div>
         {initRepositories.map((repository) => (
           <TabsContent key={repository.id} value={repository.name || ''}>
-            <Overview repository={repository} />
+            <Overview repository={repository} currentPage={currentPage} currentPageAction={setCurrentPage} />
           </TabsContent>
         ))}
       </Tabs>

--- a/src/components/home/Overview.tsx
+++ b/src/components/home/Overview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState } from 'react';
+import { Dispatch, SetStateAction, Suspense, useState } from 'react';
 
 import { RepositoryPullRequestResponseType, RepositorySummaryType } from '@/__generated__/@types';
 import { Preview } from '@/components/home/Preview';
@@ -14,11 +14,12 @@ export type ActiveCategoryIndexesType = { [key: number]: number };
 
 interface OverviewProps {
   repository: RepositorySummaryType;
+  currentPage: number;
+  currentPageAction: Dispatch<SetStateAction<number>>;
 }
 
-export function Overview({ repository }: OverviewProps) {
+export function Overview({ repository, currentPage, currentPageAction }: OverviewProps) {
   const [pullRequestId, setPullRequestId] = useState<number | undefined>(undefined);
-  const [currentPage, setCurrentPage] = useState<number>(0);
   const [activeCategoryIndexes, setActiveCategoryIndexes] = useState<ActiveCategoryIndexesType>({});
 
   const PRFetcher = repository.id === TOTAL_TABS.ID ? EntirePRFetcher : EachPRFetcher;
@@ -36,7 +37,7 @@ export function Overview({ repository }: OverviewProps) {
               totalPage={totalPage}
               pullRequestIdAction={setPullRequestId}
               currentPage={currentPage}
-              currentPageAction={setCurrentPage}
+              currentPageAction={currentPageAction}
               activeCategoryIndexesAction={setActiveCategoryIndexes}
             />
           )}

--- a/src/components/home/PRList.tsx
+++ b/src/components/home/PRList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Dispatch, SetStateAction, useEffect } from 'react';
 
 import { RepositoryPullRequestResponseType } from '@/__generated__/@types';
@@ -36,15 +37,25 @@ export function PRList({
   currentPageAction,
   activeCategoryIndexesAction,
 }: PRListProps) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
   const { pagesToShow } = usePagination({ totalPage, currentPage: currentPage + 1 });
 
   const handlePRItemOver = (pr: RepositoryPullRequestResponseType) => {
     pullRequestIdAction(pr.id);
   };
 
-  const handlePageChange = (newPage: number) => {
+  const handlePageChange = (page: number) => {
+    // 페이지 이동 시, 선택된 PRItem을 초기화 하기 위함.
     pullRequestIdAction(undefined);
-    currentPageAction(newPage);
+
+    const params = new URLSearchParams(searchParams);
+
+    currentPageAction(page);
+    params.set('page', String(page + 1));
+
+    router.push(`?${params.toString()}`, { scroll: false });
   };
 
   useEffect(() => {


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

close #158

- 기존에 제작해 둔 페이지네이션 UI를 사용해 쿼리 파라미터를 변경시킬 수 있도록 해 두었습니다.
- 이를 통해, 회고 페이지에서 뒤로 가기를 하더라도 이전에 본 페이지가 유지 될 수 있게끔 되었습니다.

## Why?

- 회고 페이지에서 뒤로가기를 하면 기본 https://dev-oops.kr 페이지로 이동하게 되어 불편했기 때문입니다.

## How?

<video src="https://github.com/user-attachments/assets/5b0f3b0d-5117-42bf-be2b-d0a887148668" />

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항

* **새로운 기능**
  * 페이지 상태가 URL에 저장되어 특정 페이지 링크를 공유하고 북마크할 수 있습니다.

* **개선 사항**
  * 탭을 전환할 때 자동으로 첫 번째 페이지로 리셋됩니다.
  * 페이지 이동 시 선택된 항목이 초기화됩니다.
  * 페이지 네비게이션이 URL과 동기화되고, 이동 시 스크롤이 유지되지 않도록 동작이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->